### PR TITLE
Mechanism for sending alerts

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -1,4 +1,4 @@
-// Copyright 3023 The ppacer Authors.
+// Copyright 2023 The ppacer Authors.
 // Licensed under the Apache License, Version 2.0.
 // See LICENSE file in the project root for full license information.
 

--- a/dag/dag.go
+++ b/dag/dag.go
@@ -129,6 +129,19 @@ func (d *Dag) GetTask(taskId string) (Task, error) {
 	return nil, ErrTaskNotFoundInDag
 }
 
+// GetNoe return DAG Node by task identifier. In case when there is no Task
+// within the DAG of given taskId, then non-nil error will be returned
+// (ErrTaskNotFoundInDag).
+func (d *Dag) GetNode(taskId string) (*Node, error) {
+	nodesInfo := d.Root.Flatten()
+	for _, ni := range nodesInfo {
+		if ni.Node.Task.Id() == taskId {
+			return ni.Node, nil
+		}
+	}
+	return nil, ErrTaskNotFoundInDag
+}
+
 // Flatten DAG into list of Tasks in BFS order.
 func (d *Dag) Flatten() []Task {
 	if d.Root == nil {

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -275,3 +275,26 @@ func TestRegistryAddDuplicate(t *testing.T) {
 		}
 	}
 }
+
+func TestGetNodeLL(t *testing.T) {
+	const size = 10
+	ll := linkedList(size)
+	llDag := New(Id("mock_dag")).AddRoot(ll).Done()
+
+	taskId := "step_5"
+	node5, n5Err := llDag.GetNode(taskId)
+	if n5Err != nil {
+		t.Errorf("Error while getting node [%s]: %s", taskId, n5Err)
+	}
+	if node5.Task.Id() != taskId {
+		t.Errorf("Expected taskId [%s], got: [%s]", taskId, node5.Task.Id())
+	}
+
+	wrongTaskId := "nonexistingtaskid"
+	_, err := llDag.GetNode(wrongTaskId)
+	if err != ErrTaskNotFoundInDag {
+		t.Errorf("Expected error [%s], but got: [%v]",
+			ErrTaskNotFoundInDag.Error(), err)
+
+	}
+}

--- a/dag/task.go
+++ b/dag/task.go
@@ -117,13 +117,26 @@ func TaskHash(t Task) string {
 // Node represents single node (vertex) in the DAG.
 type Node struct {
 	Task     Task
+	Config   TaskConfig
 	Children []*Node
 }
 
-// NewNode initialize Node with given task and returns the reference.
-func NewNode(task Task) *Node {
+// NewNode initialize Node with given task and returns the reference. For
+// custom configuration a set of TaskConfigFunc can be passed. For example:
+//
+//	var t Task = T()
+//	n1 := NewNode(t, WithTaskTimeout(10 * time.Second), WithTaskRetries(3))
+//
+// In case when no configFuncs are passed, then DefaultTaskConfig would be
+// used.
+func NewNode(task Task, configFuncs ...TaskConfigFunc) *Node {
+	config := &DefaultTaskConfig
+	for _, configFunc := range configFuncs {
+		configFunc(config)
+	}
 	n := Node{
 		Task:     task,
+		Config:   *config,
 		Children: make([]*Node, 0),
 	}
 	return &n

--- a/dag/task.go
+++ b/dag/task.go
@@ -125,12 +125,19 @@ type Node struct {
 // custom configuration a set of TaskConfigFunc can be passed. For example:
 //
 //	var t Task = T()
-//	n1 := NewNode(t, WithTaskTimeout(10 * time.Second), WithTaskRetries(3))
+//	n1 := NewNode(t, WithTaskTimeout(30), WithTaskRetries(3))
+//
+//	var t2 Task = T2()
+//	n2 := NewNode(t2, func(config *TaskConfig) {
+//			config.TimeoutSeconds = 10
+//			config.SendAlertOnRetry = true
+//		})
 //
 // In case when no configFuncs are passed, then DefaultTaskConfig would be
 // used.
 func NewNode(task Task, configFuncs ...TaskConfigFunc) *Node {
-	config := &DefaultTaskConfig
+	defConfig := DefaultTaskConfig
+	config := &defConfig
 	for _, configFunc := range configFuncs {
 		configFunc(config)
 	}

--- a/dag/task_config.go
+++ b/dag/task_config.go
@@ -1,21 +1,19 @@
 package dag
 
-import "time"
-
 // TaskConfig represents Task configuration. It contains information about
 // configuration of a task execution, like a timeout for executing given task
 // or how many times scheduler should retry in case of failures.
 type TaskConfig struct {
-	Timeout            time.Duration `json:"timeout"`
-	Retries            int           `json:"retries"`
-	SendAlertOnRetry   bool          `json:"sendAlertOnRetry"`
-	SendAlertOnFailure bool          `json:"sendAlertOnFailure"`
+	TimeoutSeconds     int  `json:"timeoutSeconds"`
+	Retries            int  `json:"retries"`
+	SendAlertOnRetry   bool `json:"sendAlertOnRetry"`
+	SendAlertOnFailure bool `json:"sendAlertOnFailure"`
 }
 
 // Default task configuration. If not specified otherwise the followig
 // configuration values would be used for Task scheduling and execution.
 var DefaultTaskConfig = TaskConfig{
-	Timeout:            1 * time.Hour,
+	TimeoutSeconds:     10 * 60,
 	Retries:            0,
 	SendAlertOnRetry:   false,
 	SendAlertOnFailure: true,
@@ -27,9 +25,9 @@ type TaskConfigFunc func(*TaskConfig)
 
 // WithTaskTimeout returns TaskConfigFunc for setting a timeout for task
 // exection.
-func WithTaskTimeout(timeout time.Duration) TaskConfigFunc {
+func WithTaskTimeout(timeoutSeconds int) TaskConfigFunc {
 	return func(config *TaskConfig) {
-		config.Timeout = timeout
+		config.TimeoutSeconds = timeoutSeconds
 	}
 }
 

--- a/dag/task_config.go
+++ b/dag/task_config.go
@@ -1,5 +1,11 @@
 package dag
 
+import (
+	"text/template"
+
+	"github.com/ppacer/core/notify"
+)
+
 // TaskConfig represents Task configuration. It contains information about
 // configuration of a task execution, like a timeout for executing given task
 // or how many times scheduler should retry in case of failures.
@@ -8,15 +14,32 @@ type TaskConfig struct {
 	Retries            int  `json:"retries"`
 	SendAlertOnRetry   bool `json:"sendAlertOnRetry"`
 	SendAlertOnFailure bool `json:"sendAlertOnFailure"`
+
+	AlertOnRetryTemplate   notify.Template `json:"-"`
+	AlertOnFailureTemplate notify.Template `json:"-"`
+}
+
+// Default template for alerts.
+func DefaultAlertTemplate() *template.Template {
+	body := `
+Task [{{.TaskId}}] in DAG [{{.DagId}}] at {{.ExecTs}} has failed.
+{{- if .TaskRunError}}
+Error:
+	{{.TaskRunError.Error}}
+{{end}}
+`
+	return template.Must(template.New("default").Parse(body))
 }
 
 // Default task configuration. If not specified otherwise the followig
 // configuration values would be used for Task scheduling and execution.
 var DefaultTaskConfig = TaskConfig{
-	TimeoutSeconds:     10 * 60,
-	Retries:            0,
-	SendAlertOnRetry:   false,
-	SendAlertOnFailure: true,
+	TimeoutSeconds:         10 * 60,
+	Retries:                0,
+	SendAlertOnRetry:       false,
+	SendAlertOnFailure:     true,
+	AlertOnRetryTemplate:   DefaultAlertTemplate(),
+	AlertOnFailureTemplate: DefaultAlertTemplate(),
 }
 
 // TaskConfigFunc is a family of functions which takes a TaskConfig and

--- a/dag/task_config.go
+++ b/dag/task_config.go
@@ -1,0 +1,54 @@
+package dag
+
+import "time"
+
+// TaskConfig represents Task configuration. It contains information about
+// configuration of a task execution, like a timeout for executing given task
+// or how many times scheduler should retry in case of failures.
+type TaskConfig struct {
+	Timeout            time.Duration `json:"timeout"`
+	Retries            int           `json:"retries"`
+	SendAlertOnRetry   bool          `json:"sendAlertOnRetry"`
+	SendAlertOnFailure bool          `json:"sendAlertOnFailure"`
+}
+
+// Default task configuration. If not specified otherwise the followig
+// configuration values would be used for Task scheduling and execution.
+var DefaultTaskConfig = TaskConfig{
+	Timeout:            1 * time.Hour,
+	Retries:            0,
+	SendAlertOnRetry:   false,
+	SendAlertOnFailure: true,
+}
+
+// TaskConfigFunc is a family of functions which takes a TaskConfig and
+// potentially updates values of given configuration.
+type TaskConfigFunc func(*TaskConfig)
+
+// WithTaskTimeout returns TaskConfigFunc for setting a timeout for task
+// exection.
+func WithTaskTimeout(timeout time.Duration) TaskConfigFunc {
+	return func(config *TaskConfig) {
+		config.Timeout = timeout
+	}
+}
+
+// WithTaskRetries returns TaskConfigFunc for setting number of retries for
+// task execution.
+func WithTaskRetries(retries int) TaskConfigFunc {
+	return func(config *TaskConfig) {
+		config.Retries = retries
+	}
+}
+
+// WithTaskSendAlertOnRetries is a TaskConfigFunc which sets sending alerts on
+// task retries.
+func WithTaskSendAlertOnRetries(config *TaskConfig) {
+	config.SendAlertOnRetry = true
+}
+
+// WithTaskNotSendAlertsOnFailures is a TaskConfigFunc which sets off sending
+// alerts on task failure.
+func WithTaskNotSendAlertsOnFailures(config *TaskConfig) {
+	config.SendAlertOnFailure = false
+}

--- a/dag/task_config_test.go
+++ b/dag/task_config_test.go
@@ -1,0 +1,72 @@
+package dag
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestNewNodeWithConfig(t *testing.T) {
+	var task Task
+	n1 := NewNode(task)
+
+	if n1.Config != DefaultTaskConfig {
+		t.Errorf("Default case should have default config, but has %+v",
+			n1.Config)
+	}
+
+	newTimeout := 30
+	n2 := NewNode(task, WithTaskTimeout(newTimeout))
+	if n2.Config.TimeoutSeconds != newTimeout {
+		t.Errorf("Expected %d timeout, but got: %d timeout seconds",
+			newTimeout, n2.Config.TimeoutSeconds)
+	}
+
+	newRetries := 1
+	n3 := NewNode(task, WithTaskRetries(newRetries))
+	if n3.Config.Retries != newRetries {
+		t.Errorf("Expected %d retires, but got: %d",
+			newRetries, n3.Config.Retries)
+	}
+
+	n4 := NewNode(task, WithTaskSendAlertOnRetries)
+	if !n4.Config.SendAlertOnRetry {
+		t.Error("Expected to send alerts on retires for this node")
+	}
+
+	n5 := NewNode(task, WithTaskNotSendAlertsOnFailures)
+	if n5.Config.SendAlertOnFailure {
+		t.Error("Expected to not send alerts on failures for this node")
+	}
+}
+
+func TestDefaultTaskConfig(t *testing.T) {
+	if DefaultTaskConfig.TimeoutSeconds < 10*60 {
+		t.Error("DefaultTaskConfig.TimeoutSeconds should be at least an hour")
+	}
+	if DefaultTaskConfig.Retries != 0 {
+		t.Error("DefaultTaskConfig.Retries should be set to 0")
+	}
+	if DefaultTaskConfig.SendAlertOnRetry {
+		t.Error("By default ppacer shouldn't send alerts on retries")
+	}
+	if !DefaultTaskConfig.SendAlertOnFailure {
+		t.Error("By default ppacer should send alerts on failures")
+	}
+}
+
+func TestDefaultTaskConfigSerialization(t *testing.T) {
+	jsonBytes, jErr := json.Marshal(DefaultTaskConfig)
+	if jErr != nil {
+		t.Errorf("Error while serializing into JSON: %s", jErr.Error())
+	}
+	if len(jsonBytes) == 0 {
+		t.Error("Expected non-empty JSON")
+	}
+	const timestampPhrase = `"timeoutSeconds":`
+	timeoutInJson := bytes.Contains(jsonBytes, []byte(timestampPhrase))
+	if !timeoutInJson {
+		t.Errorf("Expected phares [%s] in serialized JSON, but not found in %s",
+			timestampPhrase, string(jsonBytes))
+	}
+}

--- a/db/schema.go
+++ b/db/schema.go
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS dagtasks (
     InsertTs TEXT NOT NULL,         -- Insert timestamp in %Y-%m-%D %H:%M:%S format
     Version TEXT NOT NULL,          -- Scheduler Version
     TaskTypeName TEXT NOT NULL,     -- Go type name which implements this task
+    TaskConfig TEXT NOT NULL,       -- Task configuration in form of JSON
     TaskBodyHash TEXT NOT NULL,     -- Task Execute() method body source code hash
     TaskBodySource TEXT NOT NULL,   -- Task Execute() method body source code as text
 

--- a/models/api_models.go
+++ b/models/api_models.go
@@ -12,8 +12,9 @@ type TaskToExec struct {
 }
 
 type DagRunTaskStatus struct {
-	DagId  string `json:"dagId"`
-	ExecTs string `json:"execTs"`
-	TaskId string `json:"taskId"`
-	Status string `json:"status"`
+	DagId   string  `json:"dagId"`
+	ExecTs  string  `json:"execTs"`
+	TaskId  string  `json:"taskId"`
+	Status  string  `json:"status"`
+	TaskErr *string `json:"taskError"`
 }

--- a/notify/logs.go
+++ b/notify/logs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
-	"text/template"
 )
 
 // LogsErr is a notification client which "sends" notification as logs of severity
@@ -21,7 +20,7 @@ func NewLogsErr(logger *slog.Logger) *LogsErr {
 }
 
 // Send sends given message as a log of severity ERROR.
-func (l *LogsErr) Send(_ context.Context, tmpl *template.Template, data MsgData) error {
+func (l *LogsErr) Send(_ context.Context, tmpl Template, data MsgData) error {
 	var msgBuff bytes.Buffer
 	writeErr := tmpl.Execute(&msgBuff, data)
 	if writeErr != nil {

--- a/notify/logs.go
+++ b/notify/logs.go
@@ -1,9 +1,10 @@
 package notify
 
 import (
+	"bytes"
 	"context"
-	"fmt"
 	"log/slog"
+	"text/template"
 )
 
 // LogsErr is a notification client which "sends" notification as logs of severity
@@ -20,10 +21,12 @@ func NewLogsErr(logger *slog.Logger) *LogsErr {
 }
 
 // Send sends given message as a log of severity ERROR.
-func (l *LogsErr) Send(_ context.Context, msg Message) error {
-	const prefix = "[NOTIFICATION]"
-	text := fmt.Sprintf("%s [%s][%s][%s]: %s", prefix, msg.DagId, msg.ExecTs,
-		msg.TaskIdOrEmpty(), msg.Body)
-	l.logger.Error(text)
+func (l *LogsErr) Send(_ context.Context, tmpl *template.Template, data MsgData) error {
+	var msgBuff bytes.Buffer
+	writeErr := tmpl.Execute(&msgBuff, data)
+	if writeErr != nil {
+		return writeErr
+	}
+	l.logger.Error(msgBuff.String())
 	return nil
 }

--- a/notify/logs.go
+++ b/notify/logs.go
@@ -1,0 +1,29 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// LogsErr is a notification client which "sends" notification as logs of severity
+// ERROR. It implements Sender interface. It might be handy to use for local
+// development or in situations when other communications channels are not yet
+// in place.
+type LogsErr struct {
+	logger *slog.Logger
+}
+
+// NewLogsErr instantiate new LogsErr for given structured logger.
+func NewLogsErr(logger *slog.Logger) *LogsErr {
+	return &LogsErr{logger: logger}
+}
+
+// Send sends given message as a log of severity ERROR.
+func (l *LogsErr) Send(_ context.Context, msg Message) error {
+	const prefix = "[NOTIFICATION]"
+	text := fmt.Sprintf("%s [%s][%s][%s]: %s", prefix, msg.DagId, msg.ExecTs,
+		msg.TaskIdOrEmpty(), msg.Body)
+	l.logger.Error(text)
+	return nil
+}

--- a/notify/logs_test.go
+++ b/notify/logs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	htmltmpl "html/template"
 	"log/slog"
 	"slices"
 	"strings"
@@ -58,7 +59,7 @@ func TestLogsErrSimple(t *testing.T) {
 	}
 }
 
-func TestLogsErrManyTmpl(t *testing.T) {
+func TestLogsManyTmpl(t *testing.T) {
 	ctx := context.Background()
 
 	var buffor bytes.Buffer
@@ -116,6 +117,65 @@ func TestLogsErrManyTmpl(t *testing.T) {
 
 	for _, input := range inputs {
 		tmpl, parseErr := template.New("tmp").Parse(input.tmplStr)
+		if parseErr != nil {
+			t.Errorf("Error while parsing template [%s]: %s", input.tmplStr,
+				parseErr.Error())
+		}
+		sErr := logsErr.Send(ctx, tmpl, input.data)
+		if sErr != nil {
+			t.Errorf("Error while sending a message: %s", sErr.Error())
+		}
+	}
+
+	logsOutLines := strings.Split(buffor.String(), "\n")
+	logsOutLines = slices.DeleteFunc(logsOutLines, func(s string) bool {
+		return len(s) == 0 // remove empty lines (should be one at the end)
+	})
+	if len(logsOutLines) != len(inputs) {
+		t.Errorf("Expected %d notifications, got: %d",
+			len(inputs), len(logsOutLines))
+	}
+
+	for idx, input := range inputs {
+		if !strings.Contains(logsOutLines[idx], "ERR") {
+			t.Errorf("Expected ERR severity in log notification [%s], but is not",
+				logsOutLines[idx])
+		}
+		phrase := strings.TrimSpace(input.expected)
+		if !strings.Contains(logsOutLines[idx], phrase) {
+			t.Errorf("Expected [%s] in log notification [%s] (line %d), but it's not",
+				phrase, logsOutLines[idx], idx)
+		}
+	}
+}
+
+func TestLogsManyHTMLTmpl(t *testing.T) {
+	ctx := context.Background()
+
+	var buffor bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buffor, nil))
+	logsErr := NewLogsErr(logger)
+
+	inputs := []struct {
+		tmplStr  string
+		data     MsgData
+		expected string
+	}{
+		{"CONST MOCK", MsgData{}, "CONST MOCK"},
+		{
+			"<h1>{{.DagId}}</h1>",
+			MsgData{DagId: "my_dag"},
+			"<h1>my_dag</h1>",
+		},
+		{
+			"<div class='X'><p>{{.DagId}}</p></div>",
+			MsgData{DagId: "my_dag"},
+			"<div class='X'><p>my_dag</p></div>",
+		},
+	}
+
+	for _, input := range inputs {
+		tmpl, parseErr := htmltmpl.New("tmp").Parse(input.tmplStr)
 		if parseErr != nil {
 			t.Errorf("Error while parsing template [%s]: %s", input.tmplStr,
 				parseErr.Error())

--- a/notify/logs_test.go
+++ b/notify/logs_test.go
@@ -1,0 +1,64 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestLogsErrSimple(t *testing.T) {
+	const dagId = "sample_dag"
+	const execTs = "2024-06-08 22:10:00"
+	task1 := "task1"
+	ctx := context.Background()
+
+	var buffor bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buffor, nil))
+	logsErr := NewLogsErr(logger)
+
+	inputs := []struct {
+		taskId *string
+		msg    string
+	}{
+		{&task1, "test msg"},
+		{nil, "test msg for nil"},
+		{nil, ""},
+		{&task1, ""},
+	}
+
+	for _, input := range inputs {
+		err := logsErr.Send(ctx, Message{
+			DagId:  dagId,
+			ExecTs: execTs,
+			TaskId: input.taskId,
+			Body:   input.msg,
+		})
+		if err != nil {
+			t.Errorf("Error while sending notification for [%v]: %s",
+				input, err.Error())
+		}
+	}
+
+	logsOutLines := strings.Split(buffor.String(), "\n")
+	logsOutLines = slices.DeleteFunc(logsOutLines, func(s string) bool {
+		return len(s) == 0 // remove empty lines (should be one at the end)
+	})
+	if len(logsOutLines) != len(inputs) {
+		t.Errorf("Expected %d notifications, got: %d",
+			len(inputs), len(logsOutLines))
+	}
+
+	for idx, input := range inputs {
+		if !strings.Contains(logsOutLines[idx], "ERR") {
+			t.Errorf("Expected ERR severity in log notification [%s], but is not",
+				logsOutLines[idx])
+		}
+		if !strings.Contains(logsOutLines[idx], input.msg) {
+			t.Errorf("Expected [%s] to be substring of notification [%s], but is not",
+				input.msg, logsOutLines[idx])
+		}
+	}
+}

--- a/notify/mock.go
+++ b/notify/mock.go
@@ -1,0 +1,28 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+)
+
+// Mock sends message into a string slice in memory. It implements Sender
+// interface. Useful mostly for testing.
+type Mock struct {
+	buf *[]string
+}
+
+// NewMock initialized Mock for given string slice buffor.
+func NewMock(buffor *[]string) *Mock {
+	return &Mock{buf: buffor}
+}
+
+// Send sends a message onto internal Mock buffor.
+func (m *Mock) Send(_ context.Context, msg Message) error {
+	taskId := ""
+	if msg.TaskId != nil {
+		taskId = *msg.TaskId
+	}
+	text := fmt.Sprintf("%s %s %s: %s", msg.DagId, msg.ExecTs, taskId, msg.Body)
+	*m.buf = append(*m.buf, text)
+	return nil
+}

--- a/notify/mock.go
+++ b/notify/mock.go
@@ -18,7 +18,7 @@ func NewMock(buffor *[]string) *Mock {
 }
 
 // Send sends a message onto internal Mock buffor.
-func (m *Mock) Send(_ context.Context, tmpl *template.Template, data MsgData) error {
+func (m *Mock) Send(_ context.Context, tmpl Template, data MsgData) error {
 	var msgBuff bytes.Buffer
 	writeErr := tmpl.Execute(&msgBuff, data)
 	if writeErr != nil {

--- a/notify/mock_test.go
+++ b/notify/mock_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	htmltmlp "html/template"
 	"strings"
 	"testing"
 	"text/template"
@@ -151,6 +152,32 @@ func TestMockSendManyTmpl(t *testing.T) {
 			t.Errorf("For message %d, expected [%s], but got [%s]",
 				idx, input.expected, msgs[idx])
 		}
+	}
+}
+
+func TestMockSendHTML(t *testing.T) {
+	const dagId = "sample_dag"
+	ctx := context.Background()
+	msgs := make([]string, 0, 10)
+	sender := NewMock(&msgs)
+
+	tmpl, err := htmltmlp.New("mock").Parse("<h2>{{.DagId}}</h2>")
+	if err != nil {
+		t.Errorf("Cannot parse HTML template: %s", err.Error())
+	}
+
+	sErr := sender.Send(ctx, tmpl, MsgData{DagId: dagId})
+	if sErr != nil {
+		t.Errorf("Error while sending message: %s", sErr.Error())
+	}
+
+	if len(msgs) != 1 {
+		t.Errorf("Expected 1 message sent, got: %d", len(msgs))
+	}
+
+	expected := fmt.Sprintf("<h2>%s</h2>", dagId)
+	if expected != msgs[0] {
+		t.Errorf("Expected HTML message [%s], got [%s]", expected, msgs[0])
 	}
 }
 

--- a/notify/mock_test.go
+++ b/notify/mock_test.go
@@ -1,0 +1,58 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestMockSend(t *testing.T) {
+	ctx := context.Background()
+	const dagId = "sample_dag"
+	const execTs = "2024-06-08 08:56:00"
+
+	msgs := make([]string, 0, 10)
+	sender := NewMock(&msgs)
+	task1 := "task1"
+
+	inputs := []struct {
+		taskId *string
+		body   string
+	}{
+		{nil, "test message"},
+		{&task1, "test error"},
+	}
+
+	for _, input := range inputs {
+		msg := Message{
+			DagId:  dagId,
+			ExecTs: execTs,
+			TaskId: input.taskId,
+			Body:   input.body,
+		}
+		sErr := sender.Send(ctx, msg)
+		if sErr != nil {
+			t.Errorf("Error while sending a message: %s", sErr.Error())
+		}
+	}
+
+	if len(msgs) != len(inputs) {
+		t.Errorf("Expected %d messages sent, but got: %d", len(inputs),
+			len(msgs))
+	}
+
+	for idx := 0; idx < len(inputs); idx++ {
+		msgSent := msgs[idx]
+		input := inputs[idx]
+		taskId := ""
+		if input.taskId != nil {
+			taskId = *input.taskId
+		}
+		expectedMsg := fmt.Sprintf("%s %s %s: %s", dagId, execTs, taskId,
+			input.body)
+		if msgSent != expectedMsg {
+			t.Errorf("For message %d expected sent message [%s], but got [%s]",
+				idx, expectedMsg, msgSent)
+		}
+	}
+}

--- a/notify/mock_test.go
+++ b/notify/mock_test.go
@@ -1,9 +1,16 @@
 package notify
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
+	"text/template"
+	"time"
+
+	"github.com/ppacer/core/timeutils"
 )
 
 func TestMockSend(t *testing.T) {
@@ -14,23 +21,22 @@ func TestMockSend(t *testing.T) {
 	msgs := make([]string, 0, 10)
 	sender := NewMock(&msgs)
 	task1 := "task1"
+	tmpl := MockTemplate("mock")
 
 	inputs := []struct {
 		taskId *string
-		body   string
 	}{
-		{nil, "test message"},
-		{&task1, "test error"},
+		{nil},
+		{&task1},
 	}
 
 	for _, input := range inputs {
-		msg := Message{
+		msgCtx := MsgData{
 			DagId:  dagId,
 			ExecTs: execTs,
 			TaskId: input.taskId,
-			Body:   input.body,
 		}
-		sErr := sender.Send(ctx, msg)
+		sErr := sender.Send(ctx, tmpl, msgCtx)
 		if sErr != nil {
 			t.Errorf("Error while sending a message: %s", sErr.Error())
 		}
@@ -44,15 +50,164 @@ func TestMockSend(t *testing.T) {
 	for idx := 0; idx < len(inputs); idx++ {
 		msgSent := msgs[idx]
 		input := inputs[idx]
-		taskId := ""
-		if input.taskId != nil {
-			taskId = *input.taskId
+		var msgBytes bytes.Buffer
+		msgCtx := MsgData{
+			DagId:  dagId,
+			ExecTs: execTs,
+			TaskId: input.taskId,
 		}
-		expectedMsg := fmt.Sprintf("%s %s %s: %s", dagId, execTs, taskId,
-			input.body)
-		if msgSent != expectedMsg {
+		writeErr := tmpl.Execute(&msgBytes, msgCtx)
+		if writeErr != nil {
+			t.Errorf("Error while executing template: %s", writeErr.Error())
+		}
+		if msgSent != msgBytes.String() {
 			t.Errorf("For message %d expected sent message [%s], but got [%s]",
-				idx, expectedMsg, msgSent)
+				idx, msgBytes.String(), msgSent)
 		}
+	}
+}
+
+func TestMockSendManyTmpl(t *testing.T) {
+	ctx := context.Background()
+
+	msgs := make([]string, 0, 10)
+	sender := NewMock(&msgs)
+
+	inputs := []struct {
+		tmplStr  string
+		data     MsgData
+		expected string
+	}{
+		{"CONST MOCK", MsgData{}, "CONST MOCK"},
+		{
+			"Hello from {{.DagId}}",
+			MsgData{DagId: "my_dag"},
+			"Hello from my_dag",
+		},
+		{
+			"{{.DagId}}|{{.ExecTs}}",
+			MsgData{DagId: "my_dag", ExecTs: "2024-06-24"},
+			"my_dag|2024-06-24",
+		},
+		{
+			`
+				Alert for {{.DagId}} at {{.ExecTs}}
+			`,
+			MsgData{DagId: "my_dag", ExecTs: "2024-06-24"},
+			`
+				Alert for my_dag at 2024-06-24
+			`,
+		},
+		{
+			`
+				Alert for {{.DagId}} at {{.ExecTs}}
+				{{- if .TaskRunError}}
+					Error: {{.TaskRunError.Error}}
+				{{end}}
+			`,
+			MsgData{DagId: "my_dag", ExecTs: "2024-06-24"},
+			`
+				Alert for my_dag at 2024-06-24
+			`,
+		},
+		{
+			`
+				Alert for {{.DagId}} at {{.ExecTs}}
+				{{- if .TaskRunError}}
+					Error: {{.TaskRunError.Error}}
+				{{- end}}
+			`,
+			MsgData{
+				DagId:        "my_dag",
+				ExecTs:       "2024-06-24",
+				TaskRunError: errors.New("ops!"),
+			},
+			`
+				Alert for my_dag at 2024-06-24
+					Error: ops!
+			`,
+		},
+	}
+
+	for _, input := range inputs {
+		tmpl, parseErr := template.New("tmp").Parse(input.tmplStr)
+		if parseErr != nil {
+			t.Errorf("Error while parsing template [%s]: %s", input.tmplStr,
+				parseErr.Error())
+		}
+		sErr := sender.Send(ctx, tmpl, input.data)
+		if sErr != nil {
+			t.Errorf("Error while sending a message: %s", sErr.Error())
+		}
+	}
+
+	if len(msgs) != len(inputs) {
+		t.Errorf("Expected %d messages sent, but got: %d", len(inputs),
+			len(msgs))
+	}
+
+	for idx, input := range inputs {
+		if input.expected != msgs[idx] {
+			t.Errorf("For message %d, expected [%s], but got [%s]",
+				idx, input.expected, msgs[idx])
+		}
+	}
+}
+
+func TestMockTemplateNoErr(t *testing.T) {
+	taskId := "task_1"
+	data := MsgData{
+		DagId:  "sample_dag",
+		ExecTs: timeutils.ToString(time.Now()),
+		TaskId: &taskId,
+	}
+	tmpl := MockTemplate("mock")
+
+	expected := fmt.Sprintf(`
+[%s] [%s] [%s]:
+	Mock message!
+`, data.DagId, data.ExecTs, *data.TaskId)
+
+	var msgBytes bytes.Buffer
+	writeErr := tmpl.Execute(&msgBytes, data)
+	if writeErr != nil {
+		t.Errorf("Error while executing the template: %s", writeErr.Error())
+	}
+
+	expectedNospace := strings.TrimSpace(expected)
+	msgBytesNospace := strings.TrimSpace(msgBytes.String())
+
+	if expectedNospace != msgBytesNospace {
+		t.Errorf("Expected %s, but got: %s", expectedNospace, msgBytesNospace)
+	}
+}
+
+func TestMockTemplateWithErr(t *testing.T) {
+	taskId := "task_1"
+	data := MsgData{
+		DagId:        "sample_dag",
+		ExecTs:       timeutils.ToString(time.Now()),
+		TaskId:       &taskId,
+		TaskRunError: errors.New("task failed"),
+	}
+	tmpl := MockTemplate("mock")
+
+	expected := fmt.Sprintf(`
+[%s] [%s] [%s]:
+	Mock message!
+	Got error: %s
+`, data.DagId, data.ExecTs, *data.TaskId, data.TaskRunError.Error())
+
+	var msgBytes bytes.Buffer
+	writeErr := tmpl.Execute(&msgBytes, data)
+	if writeErr != nil {
+		t.Errorf("Error while executing the template: %s", writeErr.Error())
+	}
+
+	expectedNospace := strings.TrimSpace(expected)
+	msgBytesNospace := strings.TrimSpace(msgBytes.String())
+
+	if expectedNospace != msgBytesNospace {
+		t.Errorf("Expected %s, but got: %s", expectedNospace, msgBytesNospace)
 	}
 }

--- a/notify/sender.go
+++ b/notify/sender.go
@@ -20,3 +20,11 @@ type Message struct {
 	TaskId *string
 	Body   string
 }
+
+// Returns TaskId if *TaskId is not nil, else it return empty string.
+func (m Message) TaskIdOrEmpty() string {
+	if m.TaskId == nil {
+		return ""
+	}
+	return *m.TaskId
+}

--- a/notify/sender.go
+++ b/notify/sender.go
@@ -5,26 +5,23 @@
 // Package notify provides a way to send external notifications.
 package notify
 
-import "context"
+import (
+	"context"
+	"html/template"
+)
 
 // Sender sends a Message notification. Usually onto an external channel of
-// communication.
+// communication. Template should be already parsed text template which can use
+// additional information from MessageContext.
 type Sender interface {
-	Send(context.Context, Message) error
+	Send(context.Context, *template.Template, MsgData) error
 }
 
-// Message contains a message body text and DAG run contextual information.
-type Message struct {
-	DagId  string
-	ExecTs string
-	TaskId *string
-	Body   string
-}
-
-// Returns TaskId if *TaskId is not nil, else it return empty string.
-func (m Message) TaskIdOrEmpty() string {
-	if m.TaskId == nil {
-		return ""
-	}
-	return *m.TaskId
+// Message contains a DAG run contextual information.
+type MsgData struct {
+	DagId        string
+	ExecTs       string
+	TaskId       *string
+	TaskRunError error
+	RuntimeInfo  map[string]any
 }

--- a/notify/sender.go
+++ b/notify/sender.go
@@ -7,14 +7,20 @@ package notify
 
 import (
 	"context"
-	"html/template"
+	"io"
 )
+
+// Template represents a message template. Go standard text/template.Template
+// and html/template.Template satisfy this interface.
+type Template interface {
+	Execute(io.Writer, any) error
+}
 
 // Sender sends a Message notification. Usually onto an external channel of
 // communication. Template should be already parsed text template which can use
-// additional information from MessageContext.
+// additional information from MsgData.
 type Sender interface {
-	Send(context.Context, *template.Template, MsgData) error
+	Send(context.Context, Template, MsgData) error
 }
 
 // Message contains a DAG run contextual information.

--- a/notify/sender.go
+++ b/notify/sender.go
@@ -1,0 +1,22 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+// Package notify provides a way to send external notifications.
+package notify
+
+import "context"
+
+// Sender sends a Message notification. Usually onto an external channel of
+// communication.
+type Sender interface {
+	Send(context.Context, Message) error
+}
+
+// Message contains a message body text and DAG run contextual information.
+type Message struct {
+	DagId  string
+	ExecTs string
+	TaskId *string
+	Body   string
+}

--- a/scheduler/client.go
+++ b/scheduler/client.go
@@ -90,16 +90,22 @@ func (c *Client) GetTask() (models.TaskToExec, error) {
 
 // UpsertTaskStatus either updates existing DAG run task status or inserts new
 // one.
-func (c *Client) UpsertTaskStatus(tte models.TaskToExec, status dag.TaskStatus) error {
+func (c *Client) UpsertTaskStatus(tte models.TaskToExec, status dag.TaskStatus, taskErr error) error {
 	start := time.Now()
 	statusStr := status.String()
 	c.logger.Debug("Start updating task status", "taskToExec", tte, "status",
 		statusStr)
+	var taskErrStr *string = nil
+	if taskErr != nil {
+		tmp := taskErr.Error()
+		taskErrStr = &tmp
+	}
 	drts := models.DagRunTaskStatus{
-		DagId:  tte.DagId,
-		ExecTs: tte.ExecTs,
-		TaskId: tte.TaskId,
-		Status: statusStr,
+		DagId:   tte.DagId,
+		ExecTs:  tte.ExecTs,
+		TaskId:  tte.TaskId,
+		Status:  statusStr,
+		TaskErr: taskErrStr,
 	}
 	drtsJson, jErr := json.Marshal(drts)
 	if jErr != nil {

--- a/scheduler/tasks.go
+++ b/scheduler/tasks.go
@@ -508,13 +508,13 @@ func (ts *TaskScheduler) actOnFailedTask(drt DagRunTask, execErr error) error {
 
 	if drtNode.Config.SendAlertOnFailure {
 		ctx := context.TODO()
-		msg := notify.Message{
-			DagId:  string(drt.DagId),
-			ExecTs: timeutils.ToString(drt.AtTime),
-			TaskId: &drt.TaskId,
-			Body:   fmt.Sprintf("[MOCK FOR NOW] ALERT! [%s]", execErr.Error()),
+		msg := notify.MsgData{
+			DagId:        string(drt.DagId),
+			ExecTs:       timeutils.ToString(drt.AtTime),
+			TaskId:       &drt.TaskId,
+			TaskRunError: execErr,
 		}
-		ts.Notifier.Send(ctx, msg)
+		ts.Notifier.Send(ctx, drtNode.Config.AlertOnFailureTemplate, msg)
 	}
 
 	return nil

--- a/scheduler/tasks_test.go
+++ b/scheduler/tasks_test.go
@@ -134,7 +134,7 @@ func TestWalkAndScheduleOnTwoTasks(t *testing.T) {
 	ts.walkAndSchedule(ctx, dagrun, d.Root, sharedState, &wg)
 	time.Sleep(delay)
 	// Manually mark "start" task as success, to go to another task
-	uErr := ts.UpsertTaskStatus(ctx, drtStart, dag.TaskSuccess)
+	uErr := ts.UpsertTaskStatus(ctx, drtStart, dag.TaskSuccess, nil)
 	if uErr != nil {
 		t.Errorf("Error while marking <start> as Success: %s", uErr.Error())
 	}
@@ -178,7 +178,7 @@ func TestWalkAndScheduleOnAsyncTasks(t *testing.T) {
 	ts.walkAndSchedule(ctx, dagrun, d.Root, sharedState, &wg)
 	time.Sleep(delay)
 
-	uErr := ts.UpsertTaskStatus(ctx, drtStart, dag.TaskSuccess)
+	uErr := ts.UpsertTaskStatus(ctx, drtStart, dag.TaskSuccess, nil)
 	if uErr != nil {
 		t.Errorf("Error while updating dag run task status: %s", uErr.Error())
 	}
@@ -193,7 +193,7 @@ func TestWalkAndScheduleOnAsyncTasks(t *testing.T) {
 			drtN3)
 	}
 
-	uErr = ts.UpsertTaskStatus(ctx, drtN22, dag.TaskSuccess)
+	uErr = ts.UpsertTaskStatus(ctx, drtN22, dag.TaskSuccess, nil)
 	if uErr != nil {
 		t.Errorf("Error while updating dag run task %v status: %s", drtN22,
 			uErr.Error())
@@ -211,12 +211,12 @@ func TestWalkAndScheduleOnAsyncTasks(t *testing.T) {
 			drtN3)
 	}
 
-	uErr = ts.UpsertTaskStatus(ctx, drtN21, dag.TaskSuccess)
+	uErr = ts.UpsertTaskStatus(ctx, drtN21, dag.TaskSuccess, nil)
 	if uErr != nil {
 		t.Errorf("Error while updating dag run task %v status: %s", drtN21,
 			uErr.Error())
 	}
-	uErr = ts.UpsertTaskStatus(ctx, drtN23, dag.TaskSuccess)
+	uErr = ts.UpsertTaskStatus(ctx, drtN23, dag.TaskSuccess, nil)
 	if uErr != nil {
 		t.Errorf("Error while updating dag run task %v status: %s", drtN23,
 			uErr.Error())
@@ -667,7 +667,7 @@ func TestAllTasksAreDoneSimple(t *testing.T) {
 	}
 
 	drtn1 := DagRunTask{dagrun.DagId, dagrun.AtTime, "n1"}
-	uErr := ts.UpsertTaskStatus(ctx, drtn1, dag.TaskSuccess)
+	uErr := ts.UpsertTaskStatus(ctx, drtn1, dag.TaskSuccess, nil)
 	if uErr != nil {
 		t.Errorf("Cannot upsert task status for %v and %s", drtn1,
 			dag.TaskSuccess.String())
@@ -681,7 +681,7 @@ func TestAllTasksAreDoneSimple(t *testing.T) {
 
 	for _, taskId := range []string{"n21", "n22", "n23"} {
 		drt := DagRunTask{dagrun.DagId, dagrun.AtTime, taskId}
-		uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskSuccess)
+		uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskSuccess, nil)
 		if uErr != nil {
 			t.Errorf("Cannot upsert task status for %v and %s", drt,
 				dag.TaskSuccess.String())
@@ -695,7 +695,8 @@ func TestAllTasksAreDoneSimple(t *testing.T) {
 	}
 
 	drtn3 := DagRunTask{dagrun.DagId, dagrun.AtTime, "n3"}
-	uErr = ts.UpsertTaskStatus(ctx, drtn3, dag.TaskFailed)
+	errStr := "some error"
+	uErr = ts.UpsertTaskStatus(ctx, drtn3, dag.TaskFailed, &errStr)
 	if uErr != nil {
 		t.Errorf("Cannot upsert task status for %v and %s", drtn1,
 			dag.TaskSuccess.String())
@@ -724,7 +725,7 @@ func TestAllTasksAreDoneDbFallback(t *testing.T) {
 	}
 
 	drtn1 := DagRunTask{dagrun.DagId, dagrun.AtTime, "n1"}
-	uErr := ts.UpsertTaskStatus(ctx, drtn1, dag.TaskSuccess)
+	uErr := ts.UpsertTaskStatus(ctx, drtn1, dag.TaskSuccess, nil)
 	if uErr != nil {
 		t.Errorf("Cannot upsert task status for %v and %s", drtn1,
 			dag.TaskSuccess.String())
@@ -738,7 +739,7 @@ func TestAllTasksAreDoneDbFallback(t *testing.T) {
 
 	for _, taskId := range []string{"n21", "n22", "n23"} {
 		drt := DagRunTask{dagrun.DagId, dagrun.AtTime, taskId}
-		uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskSuccess)
+		uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskSuccess, nil)
 		if uErr != nil {
 			t.Errorf("Cannot upsert task status for %v and %s", drt,
 				dag.TaskSuccess.String())
@@ -982,7 +983,7 @@ func markSuccessAllTasks(
 				popErr.Error())
 		}
 		time.Sleep(taskExecutionDuration) // executor work simulation
-		uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskSuccess)
+		uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskSuccess, nil)
 		if uErr != nil {
 			t.Errorf("Error while marking %v as success: %s",
 				drt, uErr.Error())
@@ -1018,14 +1019,15 @@ func markSuccessAllTasksExceptFew(
 		}
 		time.Sleep(taskExecutionDuration) // executor work simulation
 		if _, shouldFail := taskIdsToFail[drt.TaskId]; shouldFail {
-			uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskFailed)
+			errStr := "some error"
+			uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskFailed, &errStr)
 			if uErr != nil {
 				t.Errorf("Error while marking %v as Failed: %s",
 					drt, uErr.Error())
 			}
 			continue
 		}
-		uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskSuccess)
+		uErr := ts.UpsertTaskStatus(ctx, drt, dag.TaskSuccess, nil)
 		if uErr != nil {
 			t.Errorf("Error while marking %v as success: %s",
 				drt, uErr.Error())


### PR DESCRIPTION
This PR contains:

- Introduction of `TaskConfig` - config on `dag.Node` level.
- Introduction of `notify` package which defines interface for `notify.Sender` and concreat  implementation for in-memory notifications and logs notifications.
- Setup default template for alerts on task failures in TaskConfig and using `notify.Sender` in `TaskScheduler`.