### PR TITLE
Mechanism for task retries

### DIFF
--- a/dag/task.go
+++ b/dag/task.go
@@ -56,6 +56,7 @@ const (
 	TaskSuccess
 	TaskUpstreamFailed
 	TaskNoStatus
+	TaskRestarting
 )
 
 // String serializes TaskStatus to its upper case string.
@@ -67,6 +68,7 @@ func (s TaskStatus) String() string {
 		"SUCCESS",
 		"UPSTREAM_FAILED",
 		"NO_STATUS",
+		"RESTARTING",
 	}[s]
 }
 

--- a/dag/task_config_test.go
+++ b/dag/task_config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func TestNewNodeWithConfig(t *testing.T) {
@@ -15,10 +16,10 @@ func TestNewNodeWithConfig(t *testing.T) {
 			n1.Config)
 	}
 
-	newTimeout := 30
+	newTimeout := 30 * time.Second
 	n2 := NewNode(task, WithTaskTimeout(newTimeout))
-	if n2.Config.TimeoutSeconds != newTimeout {
-		t.Errorf("Expected %d timeout, but got: %d timeout seconds",
+	if n2.Config.TimeoutSeconds != 30.0 {
+		t.Errorf("Expected %v timeout, but got: %f.2 timeout seconds",
 			newTimeout, n2.Config.TimeoutSeconds)
 	}
 
@@ -37,6 +38,13 @@ func TestNewNodeWithConfig(t *testing.T) {
 	n5 := NewNode(task, WithTaskNotSendAlertsOnFailures)
 	if n5.Config.SendAlertOnFailure {
 		t.Error("Expected to not send alerts on failures for this node")
+	}
+
+	delay := 100 * time.Millisecond
+	n6 := NewNode(task, WithTaskRetriesDelay(delay))
+	if n6.Config.RetriesDelaySeconds != 0.1 {
+		t.Errorf("Expected 0.1s RetriesDelaySeconds, but got: %f.2",
+			n6.Config.RetriesDelaySeconds)
 	}
 }
 

--- a/dag/tasklog/sqlite.go
+++ b/dag/tasklog/sqlite.go
@@ -66,6 +66,7 @@ type sqliteLogReader struct {
 func (s *sqliteLogReader) ReadAll(ctx context.Context) ([]Record, error) {
 	logs, readErr := s.dbClient.ReadDagRunTaskLogs(
 		ctx, s.ti.DagId, timeutils.ToString(s.ti.ExecTs), s.ti.TaskId,
+		s.ti.Retry,
 	)
 	if readErr != nil {
 		return nil, readErr
@@ -77,7 +78,8 @@ func (s *sqliteLogReader) ReadAll(ctx context.Context) ([]Record, error) {
 // chronological order.
 func (s *sqliteLogReader) ReadLatest(ctx context.Context, n int) ([]Record, error) {
 	logs, readErr := s.dbClient.ReadDagRunTaskLogsLatest(
-		ctx, s.ti.DagId, timeutils.ToString(s.ti.ExecTs), s.ti.TaskId, n,
+		ctx, s.ti.DagId, timeutils.ToString(s.ti.ExecTs), s.ti.TaskId,
+		s.ti.Retry, n,
 	)
 	if readErr != nil {
 		return nil, readErr
@@ -120,6 +122,7 @@ func (s *sqliteLogWriter) Write(p []byte) (int, error) {
 		DagId:      s.ti.DagId,
 		ExecTs:     timeutils.ToString(s.ti.ExecTs),
 		TaskId:     s.ti.TaskId,
+		Retry:      s.ti.Retry,
 		InsertTs:   timeutils.ToString(time.Now()),
 		Level:      lvl,
 		Message:    msg,

--- a/dag/tasklog/sqlite_test.go
+++ b/dag/tasklog/sqlite_test.go
@@ -76,6 +76,7 @@ func TestSQLiteLoggerSimple(t *testing.T) {
 
 	const dagId = "mock_dag"
 	const taskId = "task_1"
+	const retry = 0
 	ts := time.Now()
 	execTs := timeutils.ToString(ts)
 	ti := TaskInfo{DagId: dagId, ExecTs: ts, TaskId: taskId}
@@ -91,7 +92,7 @@ func TestSQLiteLoggerSimple(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tlrs, readErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId)
+	tlrs, readErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId, retry)
 	if readErr != nil {
 		t.Errorf("Error when reading tasklogs from database: %s", readErr.Error())
 	}
@@ -116,6 +117,7 @@ func TestSQLiteLoggerAttributes(t *testing.T) {
 
 	const dagId = "mock_dag"
 	const taskId = "task_1"
+	const retry = 0
 	ts := time.Now()
 	execTs := timeutils.ToString(ts)
 	ti := TaskInfo{DagId: dagId, ExecTs: ts, TaskId: taskId}
@@ -145,7 +147,7 @@ func TestSQLiteLoggerAttributes(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tlrs, readErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId)
+	tlrs, readErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId, retry)
 	if readErr != nil {
 		t.Errorf("Error when reading tasklogs from database: %s", readErr.Error())
 	}
@@ -185,6 +187,7 @@ func testSQLiteLoggerLevel(t *testing.T, lvl slog.Level, expectedRows int) {
 
 	const dagId = "mock_dag"
 	const taskId = "task_1"
+	const retry = 0
 	ts := time.Now()
 	execTs := timeutils.ToString(ts)
 	ti := TaskInfo{DagId: dagId, ExecTs: ts, TaskId: taskId}
@@ -197,7 +200,7 @@ func testSQLiteLoggerLevel(t *testing.T, lvl slog.Level, expectedRows int) {
 	sqliteLogger.Error("error")
 
 	ctx := context.Background()
-	tlrs, readErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId)
+	tlrs, readErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId, retry)
 	if readErr != nil {
 		t.Errorf("Error when reading tasklogs from database: %s", readErr.Error())
 	}

--- a/dag/tasklog/tasklog.go
+++ b/dag/tasklog/tasklog.go
@@ -16,6 +16,7 @@ type TaskInfo struct {
 	DagId  string
 	ExecTs time.Time
 	TaskId string
+	Retry  int
 }
 
 // Record represents single dag.Task log record. It doesn't contain

--- a/db/dagruntasks.go
+++ b/db/dagruntasks.go
@@ -167,7 +167,7 @@ func (c *Client) UpdateDagRunTaskStatus(ctx context.Context, dagId, execTs, task
 		execTs, "taskId", taskId, "status", status)
 	res, err := c.dbConn.ExecContext(
 		ctx, c.updateDagRunTaskStatusQuery(),
-		status, updateTs, dagId, execTs, taskId,
+		status, updateTs, dagId, execTs, taskId, retry,
 	)
 	if err != nil {
 		c.logger.Error("Cannot update dag run task status", "dagId", dagId,
@@ -335,6 +335,7 @@ func (c *Client) updateDagRunTaskStatusQuery() string {
 			DagId = ?
 		AND ExecTs = ?
 		AND TaskId = ?
+		AND Retry = ?
 	`
 }
 

--- a/db/logs_test.go
+++ b/db/logs_test.go
@@ -19,11 +19,13 @@ func TestInsertTaskLogSimple(t *testing.T) {
 	execTs := timeutils.ToString(ts)
 	const dagId = "mock_dag"
 	const taskId = "task_1"
+	const retry = 0
 
 	tlr := TaskLogRecord{
 		DagId:      dagId,
 		ExecTs:     execTs,
 		TaskId:     taskId,
+		Retry:      retry,
 		InsertTs:   execTs,
 		Level:      "INFO",
 		Message:    "Test message",
@@ -46,7 +48,7 @@ func TestInsertTaskLogSimple(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tlrs, readErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId)
+	tlrs, readErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId, retry)
 	if readErr != nil {
 		t.Errorf("Error while reading DAG run task logs: %s", readErr.Error())
 	}
@@ -70,10 +72,11 @@ func TestReadDagRunTaskLogsAllEmptyTable(t *testing.T) {
 	execTs := timeutils.ToString(ts)
 	const dagId = "mock_dag"
 	const taskId = "task_1"
+	const retry = 0
 
 	// Read all log records for the task
 	ctx := context.Background()
-	records, rErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId)
+	records, rErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId, retry)
 	if rErr != nil {
 		t.Errorf("Error while reading DAG run [%s] task [%s] logs: %s",
 			dagId, taskId, rErr.Error())
@@ -93,6 +96,7 @@ func TestReadDagRunTaskLogsAll(t *testing.T) {
 	execTs := timeutils.ToString(ts)
 	const dagId = "mock_dag"
 	const taskId = "task_1"
+	const retry = 0
 
 	// Insert loggs for a single DAG run task
 	msgs := []struct {
@@ -122,7 +126,7 @@ func TestReadDagRunTaskLogsAll(t *testing.T) {
 
 	// Read all log records for the task
 	ctx := context.Background()
-	records, rErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId)
+	records, rErr := c.ReadDagRunTaskLogs(ctx, dagId, execTs, taskId, retry)
 	if rErr != nil {
 		t.Errorf("Error while reading DAG run [%s] task [%s] logs: %s",
 			dagId, taskId, rErr.Error())
@@ -153,6 +157,7 @@ func TestReadDagRunTaskLatest(t *testing.T) {
 	execTs := timeutils.ToString(ts)
 	const dagId = "mock_dag"
 	const taskId = "task_1"
+	const retry = 0
 
 	// Insert loggs for a single DAG run task
 	msgs := []struct {
@@ -169,6 +174,7 @@ func TestReadDagRunTaskLatest(t *testing.T) {
 			DagId:      dagId,
 			ExecTs:     execTs,
 			TaskId:     taskId,
+			Retry:      retry,
 			InsertTs:   timeutils.ToString(time.Now()),
 			Level:      "INFO",
 			Message:    msg.Msg,
@@ -182,7 +188,8 @@ func TestReadDagRunTaskLatest(t *testing.T) {
 
 	// Read only the latest log record
 	ctx := context.Background()
-	records, rErr := c.ReadDagRunTaskLogsLatest(ctx, dagId, execTs, taskId, 1)
+	records, rErr := c.ReadDagRunTaskLogsLatest(ctx, dagId, execTs, taskId,
+		retry, 1)
 	if rErr != nil {
 		t.Errorf("Error while reading DAG run [%s] task [%s] logs: %s",
 			dagId, taskId, rErr.Error())
@@ -199,7 +206,8 @@ func TestReadDagRunTaskLatest(t *testing.T) {
 	}
 
 	// Read 2 latest log records
-	records, rErr = c.ReadDagRunTaskLogsLatest(ctx, dagId, execTs, taskId, 2)
+	records, rErr = c.ReadDagRunTaskLogsLatest(ctx, dagId, execTs, taskId,
+		retry, 2)
 	if rErr != nil {
 		t.Errorf("Error while reading DAG run [%s] task [%s] logs: %s",
 			dagId, taskId, rErr.Error())

--- a/db/schema.go
+++ b/db/schema.go
@@ -101,12 +101,13 @@ CREATE TABLE IF NOT EXISTS dagruntasks (
     DagId TEXT NOT NULL,            -- DAG ID
     ExecTs TEXT NOT NULL,           -- Execution timestamp
     TaskId TEXT NOT NULL,           -- Task ID
+    Retry INT NOT NULL,             -- Identifier for task retry. For initial run it's 0.
     InsertTs TEXT NOT NULL,         -- Insert timestamp
     Status TEXT NOT NULL,           -- DAG task execution status
     StatusUpdateTs TEXT NOT NULL,   -- Status update timestamp (on first insert it's the same as InsertTs)
     Version TEXT NOT NULL,          -- Scheduler version
 
-    PRIMARY KEY (DagId, ExecTs, TaskId)
+    PRIMARY KEY (DagId, ExecTs, TaskId, Retry)
 );
 `
 }

--- a/db/schema_logs.go
+++ b/db/schema_logs.go
@@ -24,12 +24,13 @@ CREATE TABLE IF NOT EXISTS tasklogs (
 	DagId TEXT NOT NULL,    -- DAG ID
 	ExecTs TEXT NOT NULL,   -- DAG run execution timestamp
 	TaskId TEXT NOT NULL,   -- Task ID
+	Retry INT NOT NULL,     -- Identifier for task retry. For initial run it's 0
 	InsertTs TEXT NOT NULL, -- Row insertion timestamp
 	Level TEXT NOT NULL,    -- Severity level
 	Message TEXT NULL,      -- Log message
 	Attributes TEXT NULL,   -- Additional log record attributes (key=value)
 
-	PRIMARY KEY (DagId ASC, ExecTs DESC, TaskId ASC, InsertTs ASC)
+	PRIMARY KEY (DagId ASC, ExecTs DESC, TaskId ASC, Retry DESC, InsertTs ASC)
 );
 `
 }

--- a/e2etests/dags.go
+++ b/e2etests/dags.go
@@ -75,6 +75,43 @@ func simpleDAGWithRuntimeErrTask(dagId dag.Id, sched *schedule.Schedule) dag.Dag
 	return d.Done()
 }
 
+func simpleDAGWithRetries(
+	dagId dag.Id, sched *schedule.Schedule, failedRuns int, retries int,
+) dag.Dag {
+	n1 := dag.NewNode(emptyTask{taskId: "start"})
+	n2 := dag.NewNode(
+		&failNTimesTask{taskId: "task1", n: failedRuns},
+		dag.WithTaskRetries(retries),
+	)
+	n3 := dag.NewNode(emptyTask{taskId: "end"})
+	n1.Next(n2).Next(n3)
+
+	d := dag.New(dagId).AddRoot(n1)
+	if sched != nil {
+		d.AddSchedule(*sched)
+	}
+	return d.Done()
+}
+
+func simpleDAGWithRetriesAndAlerts(
+	dagId dag.Id, sched *schedule.Schedule, failedRuns int, retries int,
+) dag.Dag {
+	n1 := dag.NewNode(emptyTask{taskId: "start"})
+	n2 := dag.NewNode(
+		&failNTimesTask{taskId: "task1", n: failedRuns},
+		dag.WithTaskRetries(retries),
+		dag.WithTaskSendAlertOnRetries,
+	)
+	n3 := dag.NewNode(emptyTask{taskId: "end"})
+	n1.Next(n2).Next(n3)
+
+	d := dag.New(dagId).AddRoot(n1)
+	if sched != nil {
+		d.AddSchedule(*sched)
+	}
+	return d.Done()
+}
+
 func simpleLoggingDAG(dagId dag.Id, sched *schedule.Schedule) dag.Dag {
 	n1 := dag.NewNode(logTask{taskId: "n1"})
 	n21 := dag.NewNode(logTask{taskId: "n21"})

--- a/e2etests/dags.go
+++ b/e2etests/dags.go
@@ -75,32 +75,14 @@ func simpleDAGWithRuntimeErrTask(dagId dag.Id, sched *schedule.Schedule) dag.Dag
 	return d.Done()
 }
 
-func simpleDAGWithRetries(
-	dagId dag.Id, sched *schedule.Schedule, failedRuns int, retries int,
+func simpleDAGWithTaskConfigFuncs(
+	dagId dag.Id, sched *schedule.Schedule, failedRuns int,
+	taskConfigFuncs ...dag.TaskConfigFunc,
 ) dag.Dag {
 	n1 := dag.NewNode(emptyTask{taskId: "start"})
 	n2 := dag.NewNode(
 		&failNTimesTask{taskId: "task1", n: failedRuns},
-		dag.WithTaskRetries(retries),
-	)
-	n3 := dag.NewNode(emptyTask{taskId: "end"})
-	n1.Next(n2).Next(n3)
-
-	d := dag.New(dagId).AddRoot(n1)
-	if sched != nil {
-		d.AddSchedule(*sched)
-	}
-	return d.Done()
-}
-
-func simpleDAGWithRetriesAndAlerts(
-	dagId dag.Id, sched *schedule.Schedule, failedRuns int, retries int,
-) dag.Dag {
-	n1 := dag.NewNode(emptyTask{taskId: "start"})
-	n2 := dag.NewNode(
-		&failNTimesTask{taskId: "task1", n: failedRuns},
-		dag.WithTaskRetries(retries),
-		dag.WithTaskSendAlertOnRetries,
+		taskConfigFuncs...,
 	)
 	n3 := dag.NewNode(emptyTask{taskId: "end"})
 	n1.Next(n2).Next(n3)

--- a/e2etests/dags.go
+++ b/e2etests/dags.go
@@ -51,7 +51,10 @@ func simpleDAGWithErrTaskCustomNotifier(
 	dagId dag.Id, sched *schedule.Schedule, notifier notify.Sender,
 ) dag.Dag {
 	n1 := dag.NewNode(emptyTask{taskId: "start"})
-	n2 := dag.NewNode(errTask{taskId: "task1"}, dag.WithCustomNotifier(notifier))
+	n2 := dag.NewNode(
+		errTask{taskId: "task1"},
+		dag.WithCustomNotifier(notifier),
+	)
 	n3 := dag.NewNode(emptyTask{taskId: "end"})
 	n1.Next(n2).Next(n3)
 

--- a/e2etests/simple_test.go
+++ b/e2etests/simple_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestSchedulerE2eSimpleDagEmptyTasks(t *testing.T) {
+	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -32,11 +33,12 @@ func TestSchedulerE2eSimpleDagEmptyTasks(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, t,
+		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
 	)
 }
 
 func TestSchedulerE2eSimpleDagEmptyTasksNoSched(t *testing.T) {
+	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	dagId := dag.Id("mock_dag_1")
 	dags.Add(simple131DAG(dagId, nil))
@@ -45,11 +47,12 @@ func TestSchedulerE2eSimpleDagEmptyTasksNoSched(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, t,
+		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
 	)
 }
 
 func TestSchedulerE2eLinkedListEmptyTask(t *testing.T) {
+	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -61,11 +64,12 @@ func TestSchedulerE2eLinkedListEmptyTask(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, t,
+		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
 	)
 }
 
 func TestSchedulerE2eLinkedListWaitTask(t *testing.T) {
+	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -77,11 +81,12 @@ func TestSchedulerE2eLinkedListWaitTask(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, t,
+		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
 	)
 }
 
 func TestSchedulerE2eSimpleDagWithErrTask(t *testing.T) {
+	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -92,7 +97,7 @@ func TestSchedulerE2eSimpleDagWithErrTask(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, false, &notifications, t,
+		dags, dr, 3*time.Second, false, &notifications, dbClient, t,
 	)
 
 	if len(notifications) == 0 {
@@ -140,6 +145,7 @@ func TestSchedulerE2eSimpleDagWithErrTaskCustomNotifier(t *testing.T) {
 }
 
 func TestSchedulerE2eSimpleDagWithRuntimeErrTask(t *testing.T) {
+	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -150,7 +156,7 @@ func TestSchedulerE2eSimpleDagWithRuntimeErrTask(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, false, &notifications, t,
+		dags, dr, 3*time.Second, false, &notifications, dbClient, t,
 	)
 
 	if len(notifications) == 0 {
@@ -158,82 +164,8 @@ func TestSchedulerE2eSimpleDagWithRuntimeErrTask(t *testing.T) {
 	}
 }
 
-func TestSchedulerE2eSimpleDagWithRetries(t *testing.T) {
-	const failedRuns = 3
-	const maxRetries = 3
-
-	dags := dag.Registry{}
-	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
-	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
-	dagId := dag.Id("mock_failing_dag")
-	d := simpleDAGWithTaskConfigFuncs(
-		dagId, &schedule, failedRuns, dag.WithTaskRetries(maxRetries),
-	)
-	dags.Add(d)
-	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
-	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
-	notifications := make([]string, 0)
-
-	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, t,
-	)
-}
-
-func TestSchedulerE2eSimpleDagWithFailureAfterRetries(t *testing.T) {
-	const failedRuns = 10
-	const maxRetries = 3
-
-	dags := dag.Registry{}
-	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
-	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
-	dagId := dag.Id("mock_failing_dag")
-	d := simpleDAGWithTaskConfigFuncs(
-		dagId, &schedule, failedRuns, dag.WithTaskRetries(maxRetries),
-	)
-	dags.Add(d)
-	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
-	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
-	notifications := make([]string, 0)
-
-	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, false, &notifications, t,
-	)
-}
-
-func TestSchedulerE2eSimpleDagWithRetriesAndAlerts(t *testing.T) {
-	const failedRuns = 3
-	const maxRetries = 5
-
-	dags := dag.Registry{}
-	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
-	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
-	dagId := dag.Id("mock_failing_dag")
-	d := simpleDAGWithTaskConfigFuncs(
-		dagId, &schedule, failedRuns,
-		dag.WithTaskRetries(maxRetries),
-		dag.WithTaskSendAlertOnRetries,
-	)
-	dags.Add(d)
-	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
-	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
-	notifications := make([]string, 0)
-
-	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, t,
-	)
-
-	if len(notifications) != failedRuns {
-		t.Errorf("Expected %d notification on task retries, got: %d",
-			failedRuns, len(notifications))
-
-		t.Log("notifications:")
-		for _, msg := range notifications {
-			t.Logf("  -%s\n", msg)
-		}
-	}
-}
-
 func TestSchedulerE2eTwoDagRunsSameTimeSameSchedule(t *testing.T) {
+	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	notifications := make([]string, 0)
 
@@ -255,7 +187,7 @@ func TestSchedulerE2eTwoDagRunsSameTimeSameSchedule(t *testing.T) {
 	}
 
 	testSchedulerE2eManyDagRuns(
-		dags, drs, 3*time.Second, true, &notifications, t,
+		dags, drs, 3*time.Second, true, &notifications, dbClient, t,
 	)
 }
 
@@ -275,7 +207,7 @@ func TestSchedulerE2eWritingLogsToSQLite(t *testing.T) {
 
 	// Start scheduler
 	sched, dbClient, logsDbClient := schedulerWithSqlite(
-		queues, cfg, &notifications, t,
+		queues, cfg, &notifications, nil, t,
 	)
 	testServer := httptest.NewServer(sched.Start(dags))
 	defer testServer.Close()
@@ -310,21 +242,25 @@ func TestSchedulerE2eWritingLogsToSQLite(t *testing.T) {
 }
 
 // This test runs end-to-end test (scheduler and executor run in separate
-// goroutines communicating via HTTP) for single DAG run.
+// goroutines communicating via HTTP) for single DAG run. Database client
+// (dbClient) might be nil - in this case standard SqliteTmpClient would be
+// used.
 func testSchedulerE2eSingleDagRun(
 	dags dag.Registry, dr scheduler.DagRun, timeout time.Duration,
-	expectSuccess bool, notifications *[]string, t *testing.T,
+	expectSuccess bool, notifications *[]string, dbClient *db.Client,
+	t *testing.T,
 ) {
 	t.Helper()
 	drs := []scheduler.DagRun{dr}
 	testSchedulerE2eManyDagRuns(
-		dags, drs, timeout, expectSuccess, notifications, t,
+		dags, drs, timeout, expectSuccess, notifications, dbClient, t,
 	)
 }
 
 func testSchedulerE2eManyDagRuns(
 	dags dag.Registry, drs []scheduler.DagRun, timeout time.Duration,
-	expectSuccess bool, notifications *[]string, t *testing.T,
+	expectSuccess bool, notifications *[]string, dbClient *db.Client,
+	t *testing.T,
 ) {
 	t.Helper()
 	cfg := scheduler.DefaultConfig
@@ -333,12 +269,14 @@ func testSchedulerE2eManyDagRuns(
 
 	// Start scheduler
 	sched, dbClient, logsDbClient := schedulerWithSqlite(
-		queues, cfg, notifications, t,
+		queues, cfg, notifications, dbClient, t,
 	)
 	testServer := httptest.NewServer(sched.Start(dags))
 	defer testServer.Close()
-	defer db.CleanUpSqliteTmp(dbClient, t)
-	defer db.CleanUpSqliteTmp(logsDbClient, t)
+	if dbClient == nil {
+		defer db.CleanUpSqliteTmp(dbClient, t)
+		defer db.CleanUpSqliteTmp(logsDbClient, t)
+	}
 
 	// Start executor
 	go func() {
@@ -411,12 +349,15 @@ func scheduleNewDagRun(
 
 func schedulerWithSqlite(
 	queues scheduler.Queues, config scheduler.Config, notifications *[]string,
-	t *testing.T,
+	dbClient *db.Client, t *testing.T,
 ) (*scheduler.Scheduler, *db.Client, *db.Client) {
 	t.Helper()
-	dbClient, err := db.NewSqliteTmpClient(nil)
-	if err != nil {
-		t.Fatal(err)
+	if dbClient == nil {
+		var err error
+		dbClient, err = db.NewSqliteTmpClient(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	logsDbClient, lErr := db.NewSqliteTmpClientForLogs(nil)
 	if lErr != nil {

--- a/e2etests/simple_test.go
+++ b/e2etests/simple_test.go
@@ -103,15 +103,14 @@ func TestSchedulerE2eSimpleDagWithErrTask(t *testing.T) {
 	if len(notifications) == 0 {
 		t.Error("Expected at least one error notification, but got zero")
 	}
-	/*
-		t.Log("Notifications:")
-		for _, n := range notifications {
-			t.Log(n)
-		}
-	*/
+	t.Log("Notifications:")
+	for _, n := range notifications {
+		t.Log(n)
+	}
 }
 
 func TestSchedulerE2eSimpleDagWithErrTaskCustomNotifier(t *testing.T) {
+	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -124,7 +123,7 @@ func TestSchedulerE2eSimpleDagWithErrTaskCustomNotifier(t *testing.T) {
 	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, false, &notifications, t,
+		dags, dr, 3*time.Second, false, &notifications, dbClient, t,
 	)
 
 	if len(notifications) == 0 {
@@ -136,12 +135,6 @@ func TestSchedulerE2eSimpleDagWithErrTaskCustomNotifier(t *testing.T) {
 				idx, notification, notifierPhrase)
 		}
 	}
-	/*
-		t.Log("Notifications:")
-		for _, n := range notifications {
-			t.Log(n)
-		}
-	*/
 }
 
 func TestSchedulerE2eSimpleDagWithRuntimeErrTask(t *testing.T) {

--- a/e2etests/task_retries_test.go
+++ b/e2etests/task_retries_test.go
@@ -1,0 +1,242 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+package e2etests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ppacer/core/dag"
+	"github.com/ppacer/core/dag/schedule"
+	"github.com/ppacer/core/db"
+	"github.com/ppacer/core/scheduler"
+	"github.com/ppacer/core/timeutils"
+)
+
+func TestSimpleDagRunWithRetries(t *testing.T) {
+	const failedRuns = 3
+	const maxRetries = 3
+
+	var dbClient *db.Client = nil
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("mock_failing_dag")
+	d := simpleDAGWithTaskConfigFuncs(
+		dagId, &schedule, failedRuns, dag.WithTaskRetries(maxRetries),
+	)
+	dags.Add(d)
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+	notifications := make([]string, 0)
+
+	testSchedulerE2eSingleDagRun(
+		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+	)
+}
+
+func TestSimpleDagRunWithZeroRetries(t *testing.T) {
+	var dbClient *db.Client = nil
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("mock_failing_dag")
+	d := simpleDAGWithTaskConfigFuncs(
+		dagId, &schedule, 0, dag.WithTaskRetries(0), // the same as no retries
+	)
+	dags.Add(d)
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+	notifications := make([]string, 0)
+
+	testSchedulerE2eSingleDagRun(
+		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+	)
+}
+
+func TestSimpleDagRunWithFailureAfterRetries(t *testing.T) {
+	const failedRuns = 10
+	const maxRetries = 3
+
+	var dbClient *db.Client = nil
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("mock_failing_dag")
+	d := simpleDAGWithTaskConfigFuncs(
+		dagId, &schedule, failedRuns, dag.WithTaskRetries(maxRetries),
+	)
+	dags.Add(d)
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+	notifications := make([]string, 0)
+
+	testSchedulerE2eSingleDagRun(
+		dags, dr, 3*time.Second, false, &notifications, dbClient, t,
+	)
+}
+
+func TestSimpleDagRunWithRetriesAndAlerts(t *testing.T) {
+	const failedRuns = 3
+	const maxRetries = 5
+
+	var dbClient *db.Client = nil
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("mock_failing_dag")
+	d := simpleDAGWithTaskConfigFuncs(
+		dagId, &schedule, failedRuns,
+		dag.WithTaskRetries(maxRetries),
+		dag.WithTaskSendAlertOnRetries,
+	)
+	dags.Add(d)
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+	notifications := make([]string, 0)
+
+	testSchedulerE2eSingleDagRun(
+		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+	)
+
+	if len(notifications) != failedRuns {
+		t.Errorf("Expected %d notification on task retries, got: %d",
+			failedRuns, len(notifications))
+
+		t.Log("notifications:")
+		for _, msg := range notifications {
+			t.Logf("  -%s\n", msg)
+		}
+	}
+}
+
+func TestDagRunWithParallelRetries(t *testing.T) {
+	var dbClient *db.Client = nil
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("mock_failing_dag")
+	dags.Add(simple131DagWithRetries(dagId, &schedule))
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+	notifications := make([]string, 0)
+
+	testSchedulerE2eSingleDagRun(
+		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+	)
+
+	if len(notifications) == 0 {
+		t.Error("Expected at least 1 notification on task retries, got: 0")
+	}
+}
+
+func simple131DagWithRetries(dagId dag.Id, sched *schedule.Schedule) dag.Dag {
+	n1 := dag.NewNode(emptyTask{taskId: "n1"})
+	n21 := dag.NewNode(
+		&failNTimesTask{taskId: "n21", n: 1},
+		dag.WithTaskRetries(3),
+		dag.WithTaskSendAlertOnRetries,
+	)
+	n22 := dag.NewNode(emptyTask{taskId: "n22"})
+	n23 := dag.NewNode(
+		&failNTimesTask{taskId: "n23", n: 4},
+		dag.WithTaskRetries(5),
+	)
+	n3 := dag.NewNode(emptyTask{taskId: "n3"})
+	n1.NextAsyncAndMerge([]*dag.Node{n21, n22, n23}, n3)
+
+	d := dag.New(dagId)
+	d.AddRoot(n1)
+	d.AddAttributes(dag.Attr{CatchUp: false})
+
+	if sched != nil {
+		d.AddSchedule(*sched)
+	}
+	return d.Done()
+}
+
+func TestDagRunWithDelayedRetries(t *testing.T) {
+	const failedRuns = 2
+	const maxRetries = 5
+	const taskIdWithRetries = "task1"
+	delayBeforeRetry := 256 * time.Millisecond
+
+	dbClient, err := db.NewSqliteTmpClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.CleanUpSqliteTmp(dbClient, t)
+
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("mock_failing_dag")
+	d := simpleDAGWithTaskConfigFuncs(
+		dagId, &schedule, failedRuns,
+		dag.WithTaskRetries(maxRetries),
+		dag.WithTaskRetriesDelay(delayBeforeRetry),
+	)
+	dags.Add(d)
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+	notifications := make([]string, 0)
+
+	testSchedulerE2eSingleDagRun(
+		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+	)
+
+	ctx := context.Background()
+	drts, readErr := dbClient.ReadDagRunTasks(
+		ctx, string(dagId), timeutils.ToString(ts),
+	)
+	if readErr != nil {
+		t.Errorf("Could not read dag run tasks from the database: %s",
+			readErr.Error())
+	}
+	expectedNumOfTasks := failedRuns + 1 + 2
+	if len(drts) != expectedNumOfTasks {
+		t.Errorf("Expected %d tasks in the dagruntasks table, got: %d",
+			expectedNumOfTasks, len(drts))
+	}
+	testGapDurationBetweenTasks(drts, taskIdWithRetries, delayBeforeRetry, t)
+}
+
+func testGapDurationBetweenTasks(
+	drts []db.DagRunTask, taskId string, expectedDelay time.Duration,
+	t *testing.T,
+) {
+	t.Helper()
+	if len(drts) <= 1 {
+		t.Fatalf("Expected at least two DAG run tasks, got: %d", len(drts))
+	}
+	insertTimestamps := make([]time.Time, 0, len(drts))
+	for _, drt := range drts {
+		if drt.TaskId != taskId {
+			continue
+		}
+		ts, castErr := timeutils.FromString(drt.InsertTs)
+		if castErr != nil {
+			t.Errorf("Cannot convert %s into time.Time: %s", drt.InsertTs,
+				castErr.Error())
+		}
+		insertTimestamps = append(insertTimestamps, ts)
+	}
+	if len(insertTimestamps) <= 1 {
+		t.Fatalf("Expected at least two records for taskId=%s, but got: %d",
+			taskId, len(insertTimestamps))
+	}
+
+	prevTs := insertTimestamps[0]
+	for idx := 1; idx < len(insertTimestamps); idx++ {
+		ts := insertTimestamps[idx]
+		timeDiff := ts.Sub(prevTs)
+		if timeDiff < expectedDelay {
+			t.Errorf("Expected at least %v delay, got %v for prev=%v current=%v",
+				expectedDelay, timeDiff, prevTs, ts)
+		}
+		prevTs = ts
+	}
+}

--- a/e2etests/tasks.go
+++ b/e2etests/tasks.go
@@ -6,6 +6,7 @@ package e2etests
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/ppacer/core/dag"
@@ -66,5 +67,27 @@ func (ret runtimeErrTask) Execute(tc dag.TaskContext) error {
 	one := 1
 	zero := 1 - one
 	tc.Logger.Info("Test", "number", 42/zero)
+	return nil
+}
+
+// Task which fails n times and succeed on n+1 run.
+type failNTimesTask struct {
+	taskId     string
+	n          int
+	currentRun int
+}
+
+func (fnt *failNTimesTask) Id() string { return fnt.taskId }
+
+func (fnt *failNTimesTask) Execute(tc dag.TaskContext) error {
+	fnt.currentRun += 1
+	if fnt.currentRun <= fnt.n {
+		tc.Logger.Error("this is failing run", "currentRun", fnt.currentRun,
+			"n", fnt.n)
+		return fmt.Errorf("this is failing run %d (<=%d)", fnt.currentRun,
+			fnt.n)
+	}
+	tc.Logger.Info("this run is fine", "currentRun", fnt.currentRun, "n",
+		fnt.n)
 	return nil
 }

--- a/exec/executor.go
+++ b/exec/executor.go
@@ -155,7 +155,12 @@ func executeTask(
 
 	// Executing
 	ri := dag.RunInfo{DagId: dag.Id(tte.DagId), ExecTs: execTs}
-	ti := tasklog.TaskInfo{DagId: tte.DagId, ExecTs: execTs, TaskId: task.Id()}
+	ti := tasklog.TaskInfo{
+		DagId:  tte.DagId,
+		ExecTs: execTs,
+		TaskId: task.Id(),
+		Retry:  tte.Retry,
+	}
 
 	taskContext := dag.TaskContext{
 		Context:  context.TODO(),

--- a/models/api_models.go
+++ b/models/api_models.go
@@ -9,6 +9,7 @@ type TaskToExec struct {
 	DagId  string `json:"dagId"`
 	ExecTs string `json:"execTs"`
 	TaskId string `json:"taskId"`
+	Retry  int    `json:"retry"`
 }
 
 type DagRunTaskStatus struct {

--- a/models/api_models.go
+++ b/models/api_models.go
@@ -16,6 +16,7 @@ type DagRunTaskStatus struct {
 	DagId   string  `json:"dagId"`
 	ExecTs  string  `json:"execTs"`
 	TaskId  string  `json:"taskId"`
+	Retry   int     `json:"retry"`
 	Status  string  `json:"status"`
 	TaskErr *string `json:"taskError"`
 }

--- a/notify/sender.go
+++ b/notify/sender.go
@@ -28,6 +28,7 @@ type MsgData struct {
 	DagId        string
 	ExecTs       string
 	TaskId       *string
+	Retry        int
 	TaskRunError error
 	RuntimeInfo  map[string]any
 }

--- a/scheduler/client.go
+++ b/scheduler/client.go
@@ -104,6 +104,7 @@ func (c *Client) UpsertTaskStatus(tte models.TaskToExec, status dag.TaskStatus, 
 		DagId:   tte.DagId,
 		ExecTs:  tte.ExecTs,
 		TaskId:  tte.TaskId,
+		Retry:   tte.Retry,
 		Status:  statusStr,
 		TaskErr: taskErrStr,
 	}

--- a/scheduler/client_test.go
+++ b/scheduler/client_test.go
@@ -49,7 +49,7 @@ func TestClientGetTaskMockSingle(t *testing.T) {
 
 	schedClient := NewClient(testServer.URL, nil, nil, DefaultClientConfig)
 
-	drt := DagRunTask{dag.Id("mock_dag"), time.Now(), "task1"}
+	drt := DagRunTask{dag.Id("mock_dag"), time.Now(), "task1", 0}
 	putErr := queues.DagRunTasks.Put(drt)
 	if putErr != nil {
 		t.Errorf("Cannot put new DAG run task onto the queue: %s",
@@ -92,11 +92,11 @@ func TestClientGetTaskMockMany(t *testing.T) {
 
 	dagId := dag.Id("mock_dag")
 	data := []DagRunTask{
-		{dagId, time.Now(), "task1"},
-		{dagId, time.Now(), "task2"},
-		{dagId, time.Now(), "task3"},
-		{dagId, time.Now(), "task4"},
-		{dagId, time.Now(), "task5"},
+		{dagId, time.Now(), "task1", 0},
+		{dagId, time.Now(), "task2", 0},
+		{dagId, time.Now(), "task3", 0},
+		{dagId, time.Now(), "task4", 0},
+		{dagId, time.Now(), "task5", 0},
 	}
 
 	// Put tasks onto the task queue
@@ -172,7 +172,7 @@ func TestClientUpsertTaskSimpleUpdate(t *testing.T) {
 	// Insert tasks with SCHEDULED status
 	for _, taskId := range taskIds {
 		iErr := scheduler.dbClient.InsertDagRunTask(ctx, dagId, execTs, taskId,
-			initStatus)
+			0, initStatus)
 		if iErr != nil {
 			t.Errorf("Cannot insert DAG run task into DB: %s", iErr.Error())
 		}
@@ -302,7 +302,7 @@ func readDagRunTaskFromDb(
 ) db.DagRunTask {
 	t.Helper()
 	ctx := context.Background()
-	drt, dbErr := dbClient.ReadDagRunTask(ctx, dagId, execTs, taskId)
+	drt, dbErr := dbClient.ReadDagRunTask(ctx, dagId, execTs, taskId, 0)
 	if dbErr != nil {
 		t.Errorf("Cannot read DAG run task (%s, %s, %s) from DB: %s",
 			dagId, execTs, taskId, dbErr.Error())

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -45,21 +45,26 @@ var DefaultConfig Config = Config{
 	DagRunWatcherConfig:   DefaultDagRunWatcherConfig,
 }
 
-// Configuration for taskScheduler which is responsible for scheduling tasks
+// Configuration for TaskScheduler which is responsible for scheduling tasks
 // for particular DAG run.
 type TaskSchedulerConfig struct {
-	// How long taskScheduler should wait in case when DAG run queue is empty.
+	// How long TaskScheduler should wait in case when DAG run queue is empty.
 	Heartbeat time.Duration
 
-	// How often taskScheduler should check if all dependencies are met before
+	// How often TaskScheduler should check if all dependencies are met before
 	// scheduling new task. Expressed in milliseconds.
 	CheckDependenciesStatusWait time.Duration
+
+	// How long TaskScheduler should try to put new DAG run task onto the task
+	// queue.
+	PutOnTaskQueueTimeout time.Duration
 }
 
 // Default taskScheduler configuration.
 var DefaultTaskSchedulerConfig TaskSchedulerConfig = TaskSchedulerConfig{
 	Heartbeat:                   1 * time.Millisecond,
 	CheckDependenciesStatusWait: 1 * time.Millisecond,
+	PutOnTaskQueueTimeout:       30 * time.Second,
 }
 
 // Configuration for DagRunWatcher which is responsible for scheduling new DAG

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -89,7 +89,7 @@ func DefaultStarted(dags dag.Registry, dbFile string, port int) *http.Server {
 // executors. TODO(dskrzypiec): more docs
 func (s *Scheduler) Start(dags dag.Registry) http.Handler {
 	cacheSize := s.config.DagRunTaskCacheLen
-	taskCache := ds.NewLruCache[DagRunTask, DagRunTaskState](cacheSize)
+	taskCache := ds.NewLruCache[DRTBase, DagRunTaskState](cacheSize)
 
 	// Syncing queues with the database in case of program restarts.
 	s.setState(StateSynchronizing)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -169,11 +169,11 @@ func (s *Scheduler) currentState(w http.ResponseWriter, _ *http.Request) {
 
 // HTTP handler for popping dag run task from the queue.
 func (ts *TaskScheduler) popTask(w http.ResponseWriter, _ *http.Request) {
-	if ts.TaskQueue.Size() == 0 {
+	if ts.taskQueue.Size() == 0 {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	drt, err := ts.TaskQueue.Pop()
+	drt, err := ts.taskQueue.Pop()
 	if err == ds.ErrQueueIsEmpty {
 		w.WriteHeader(http.StatusNoContent)
 		return
@@ -243,7 +243,7 @@ func (ts *TaskScheduler) upsertTaskStatus(w http.ResponseWriter, r *http.Request
 		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
-	ts.Logger.Debug("Updated task status", "dagruntask", drt, "status", status,
+	ts.logger.Debug("Updated task status", "dagruntask", drt, "status", status,
 		"duration", time.Since(start))
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -232,6 +232,7 @@ func (ts *TaskScheduler) upsertTaskStatus(w http.ResponseWriter, r *http.Request
 		DagId:  dag.Id(drts.DagId),
 		AtTime: execTs,
 		TaskId: drts.TaskId,
+		Retry:  drts.Retry,
 	}
 
 	ctx := context.TODO()

--- a/scheduler/start.go
+++ b/scheduler/start.go
@@ -166,7 +166,7 @@ func syncDagRunsQueue(
 // tasks are greater than size of the cache, then older tasks won't fit into
 // the cache. Newer tasks are more relevant.
 func syncDagRunTaskCache(
-	cache ds.Cache[DagRunTask, DagRunTaskState],
+	cache ds.Cache[DRTBase, DagRunTaskState],
 	dbClient *db.Client,
 	logger *slog.Logger,
 	config Config,
@@ -178,7 +178,7 @@ func syncDagRunTaskCache(
 		return dbErr
 	}
 	for _, drtDb := range drtNotFinished {
-		drt := DagRunTask{
+		drt := DRTBase{
 			DagId:  dag.Id(drtDb.DagId),
 			AtTime: timeutils.FromStringMust(drtDb.ExecTs),
 			TaskId: drtDb.TaskId,

--- a/scheduler/start_test.go
+++ b/scheduler/start_test.go
@@ -338,7 +338,7 @@ func TestSyncDagRunTaskCacheEmpty(t *testing.T) {
 	}
 
 	const size = 10
-	drtCache := ds.NewLruCache[DagRunTask, DagRunTaskState](size)
+	drtCache := ds.NewLruCache[DRTBase, DagRunTaskState](size)
 	syncErr := syncDagRunTaskCache(drtCache, c, simpleLogger(), DefaultConfig)
 	if syncErr != nil {
 		t.Errorf("Error while syncing DAG run tasks cache: %s", syncErr.Error())
@@ -376,7 +376,7 @@ func TestSyncDagRunTaskCacheSimple(t *testing.T) {
 
 	const size = 10
 	const expected = 3
-	drtCache := ds.NewLruCache[DagRunTask, DagRunTaskState](size)
+	drtCache := ds.NewLruCache[DRTBase, DagRunTaskState](size)
 	syncErr := syncDagRunTaskCache(drtCache, c, simpleLogger(), DefaultConfig)
 	if syncErr != nil {
 		t.Errorf("Error while syncing DAG run tasks cache: %s", syncErr.Error())
@@ -396,7 +396,7 @@ func TestSyncDagRunTaskCacheSimple(t *testing.T) {
 		{"dag3", "T", dag.TaskRunning},
 	}
 	for _, e := range expectedInCache {
-		drts, exists := drtCache.Get(drt(e.dagId, ts, e.taskId))
+		drts, exists := drtCache.Get(drt(e.dagId, ts, e.taskId).Base())
 		if !exists {
 			t.Errorf("Expected DAG run task %s.%s.%s to be in the cache",
 				e.dagId, ts, e.taskId)
@@ -435,7 +435,7 @@ func TestSyncDagRunTaskCacheSmall(t *testing.T) {
 		insertDagRunTask(c, ctx, d.dagId, ts, d.taskId, d.status.String(), t)
 	}
 
-	drtCache := ds.NewLruCache[DagRunTask, DagRunTaskState](size)
+	drtCache := ds.NewLruCache[DRTBase, DagRunTaskState](size)
 	syncErr := syncDagRunTaskCache(drtCache, c, simpleLogger(), DefaultConfig)
 	if syncErr != nil {
 		t.Errorf("Error while syncing DAG run tasks cache: %s", syncErr.Error())
@@ -446,7 +446,7 @@ func TestSyncDagRunTaskCacheSmall(t *testing.T) {
 	}
 
 	// dag1.ts.task3 should not be in the cache in case when cache size is 2.
-	_, d1t3Exists := drtCache.Get(drt("dag1", ts, "task3"))
+	_, d1t3Exists := drtCache.Get(drt("dag1", ts, "task3").Base())
 	if d1t3Exists {
 		t.Errorf("DAG run task dag1.%s.task3 should not be in the cache, but it is",
 			ts)
@@ -461,7 +461,7 @@ func TestSyncDagRunTaskCacheSmall(t *testing.T) {
 		{"dag3", "T", dag.TaskRunning},
 	}
 	for _, e := range expectedInCache {
-		drts, exists := drtCache.Get(drt(e.dagId, ts, e.taskId))
+		drts, exists := drtCache.Get(drt(e.dagId, ts, e.taskId).Base())
 		if !exists {
 			t.Errorf("Expected DAG run task %s.%s.%s to be in the cache",
 				e.dagId, ts, e.taskId)

--- a/scheduler/start_test.go
+++ b/scheduler/start_test.go
@@ -504,7 +504,7 @@ func insertDagRunTask(
 	dagId, execTs, taskId, status string,
 	t *testing.T,
 ) {
-	iErr := c.InsertDagRunTask(ctx, dagId, execTs, taskId, status)
+	iErr := c.InsertDagRunTask(ctx, dagId, execTs, taskId, 0, status)
 	if iErr != nil {
 		t.Errorf("Error while inserting dag run: %s", iErr.Error())
 	}

--- a/scheduler/tasks.go
+++ b/scheduler/tasks.go
@@ -1,5 +1,5 @@
 // Copyright 2023 The ppacer Authors.
-// Licensed under the Apach.WithNoRetry()e License, Version 2.0.
+// Licensed under the Apache License, Version 2.0.
 // See LICENSE file in the project root for full license information.
 
 package scheduler

--- a/scheduler/tasks_failed.go
+++ b/scheduler/tasks_failed.go
@@ -1,0 +1,122 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/ppacer/core/dag"
+	"github.com/ppacer/core/db"
+	"github.com/ppacer/core/ds"
+	"github.com/ppacer/core/notify"
+	"github.com/ppacer/core/timeutils"
+)
+
+// TODO
+type failedTaskManager struct {
+	dags      dag.Registry
+	dbClient  *db.Client
+	taskQueue ds.Queue[DagRunTask]
+	taskCache ds.Cache[DagRunTask, DagRunTaskState]
+	config    TaskSchedulerConfig
+	logger    *slog.Logger
+}
+
+// Initialize new failedTaskManager.
+func newFailedTaskManager(
+	dags dag.Registry,
+	dbClient *db.Client,
+	taskQueue ds.Queue[DagRunTask],
+	taskCache ds.Cache[DagRunTask, DagRunTaskState],
+	config TaskSchedulerConfig,
+	logger *slog.Logger,
+) *failedTaskManager {
+	return &failedTaskManager{
+		dags:      dags,
+		dbClient:  dbClient,
+		taskQueue: taskQueue,
+		taskCache: taskCache,
+		config:    config,
+		logger:    logger,
+	}
+}
+
+// ShouldBeRetried checks
+func (ftm *failedTaskManager) ShouldBeRetried(
+	drt DagRunTask, status dag.TaskStatus,
+) (bool, error) {
+	if status != dag.TaskFailed {
+		// Non-failed DAG run task shouldn't be retried.
+		return false, nil
+	}
+
+	drtNode, nodeErr := ftm.getDrtNode(drt)
+	if nodeErr != nil {
+		return false, nodeErr
+	}
+
+	if drtNode.Config.Retries == 0 {
+		// no retries!
+		return false, nil
+	}
+	return drt.Retry < drtNode.Config.Retries, nil
+}
+
+// CheckAndSendAlerts checks if in given situation external notification should
+// be sent and if so, it will send it.
+func (ftm *failedTaskManager) CheckAndSendAlerts(
+	drt DagRunTask, status dag.TaskStatus, shouldBeRetried bool,
+	taskErrStr *string, notifier notify.Sender,
+) error {
+	drtNode, nodeErr := ftm.getDrtNode(drt)
+	if nodeErr != nil {
+		return nodeErr
+	}
+
+	var taskErr error = nil
+	if taskErrStr == nil {
+		ftm.logger.Error("Got failed task with empty task error",
+			"dagruntask", drt, "status", status.String())
+	} else {
+		taskErr = fmt.Errorf("%s", *taskErrStr)
+	}
+
+	ctx := context.TODO()
+	msg := notify.MsgData{
+		DagId:        string(drt.DagId),
+		ExecTs:       timeutils.ToString(drt.AtTime),
+		TaskId:       &drt.TaskId,
+		TaskRunError: taskErr,
+	}
+
+	if shouldBeRetried && drtNode.Config.SendAlertOnRetry {
+		return notifier.Send(ctx, drtNode.Config.AlertOnRetryTemplate, msg)
+	}
+
+	if drtNode.Config.SendAlertOnFailure {
+		return notifier.Send(ctx, drtNode.Config.AlertOnFailureTemplate, msg)
+	}
+	return nil
+}
+
+func (ftm *failedTaskManager) getDrtNode(drt DagRunTask) (*dag.Node, error) {
+	dag, exists := ftm.dags[drt.DagId]
+	if !exists {
+		return nil, fmt.Errorf("dag [%s] does not exist in the registry",
+			string(drt.DagId))
+	}
+	drtNode, nErr := dag.GetNode(drt.TaskId)
+	if nErr != nil {
+		return drtNode, nErr
+	}
+	if drtNode == nil {
+		return nil,
+			fmt.Errorf("expected non-nil dag.Node for DAG=%s and Task=%s",
+				drt.DagId, drt.TaskId)
+	}
+	return drtNode, nil
+}

--- a/scheduler/tasks_failed.go
+++ b/scheduler/tasks_failed.go
@@ -21,7 +21,7 @@ type failedTaskManager struct {
 	dags      dag.Registry
 	dbClient  *db.Client
 	taskQueue ds.Queue[DagRunTask]
-	taskCache ds.Cache[DagRunTask, DagRunTaskState]
+	taskCache ds.Cache[DRTBase, DagRunTaskState]
 	config    TaskSchedulerConfig
 	logger    *slog.Logger
 }
@@ -31,7 +31,7 @@ func newFailedTaskManager(
 	dags dag.Registry,
 	dbClient *db.Client,
 	taskQueue ds.Queue[DagRunTask],
-	taskCache ds.Cache[DagRunTask, DagRunTaskState],
+	taskCache ds.Cache[DRTBase, DagRunTaskState],
 	config TaskSchedulerConfig,
 	logger *slog.Logger,
 ) *failedTaskManager {

--- a/scheduler/tasks_failed.go
+++ b/scheduler/tasks_failed.go
@@ -17,7 +17,9 @@ import (
 	"github.com/ppacer/core/timeutils"
 )
 
-// TODO
+// FailedTaskManager covers complexity of the logic behind handling failed
+// tasks. That includes a decision whenever a task should be retried and
+// decision about sending external notification.
 type failedTaskManager struct {
 	dags      dag.Registry
 	dbClient  *db.Client
@@ -66,7 +68,9 @@ func (ftm *failedTaskManager) ShouldBeRetried(
 		// no retries!
 		return false, 0, nil
 	}
-	delay := time.Duration(drtNode.Config.RetriesDelaySeconds * float64(time.Second))
+	delay := time.Duration(
+		drtNode.Config.RetriesDelaySeconds * float64(time.Second),
+	)
 	return drt.Retry < drtNode.Config.Retries, delay, nil
 }
 

--- a/scheduler/tasks_failed.go
+++ b/scheduler/tasks_failed.go
@@ -93,6 +93,10 @@ func (ftm *failedTaskManager) CheckAndSendAlerts(
 		taskErr = fmt.Errorf("%s", *taskErrStr)
 	}
 
+	if drtNode.Config.Notifier != nil {
+		notifier = drtNode.Config.Notifier
+	}
+
 	ctx := context.TODO()
 	msg := notify.MsgData{
 		DagId:        string(drt.DagId),

--- a/scheduler/tasks_failed_test.go
+++ b/scheduler/tasks_failed_test.go
@@ -83,7 +83,7 @@ func newFailedTaskManagerForTests(t *testing.T) *failedTaskManager {
 	}
 	dags := dag.Registry{}
 	taskQueue := ds.NewSimpleQueue[DagRunTask](100)
-	taskCache := ds.NewLruCache[DagRunTask, DagRunTaskState](100)
+	taskCache := ds.NewLruCache[DRTBase, DagRunTaskState](100)
 	return newFailedTaskManager(
 		dags, dbClient, &taskQueue, taskCache, DefaultTaskSchedulerConfig,
 		simpleLogger(),

--- a/scheduler/tasks_failed_test.go
+++ b/scheduler/tasks_failed_test.go
@@ -1,0 +1,91 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ppacer/core/dag"
+	"github.com/ppacer/core/db"
+	"github.com/ppacer/core/ds"
+)
+
+func TestSchouldBeRetried(t *testing.T) {
+	const dagId = "linear_dag"
+	execTs := time.Now()
+	ftm := newFailedTaskManagerForTests(t)
+	defer db.CleanUpSqliteTmp(ftm.dbClient, t)
+
+	et := func(taskId string) EmptyTask {
+		return EmptyTask{TaskId: taskId}
+	}
+
+	newDrt := func(taskId string, retry int) DagRunTask {
+		return DagRunTask{
+			DagId:  dagId,
+			AtTime: execTs,
+			TaskId: taskId,
+			Retry:  retry,
+		}
+	}
+
+	root := dag.NewNode(EmptyTask{TaskId: "start"})
+	tail := root
+	linearDag := dag.New(dag.Id(dagId)).AddRoot(root).Done()
+	ftm.dags.Add(linearDag)
+
+	nodes := []*dag.Node{
+		dag.NewNode(et("t1")),
+		dag.NewNode(et("t2"), dag.WithTaskRetries(10)),
+		// TODO: more nodes
+	}
+
+	// Expand DAG before
+	for _, node := range nodes {
+		tail.Next(node)
+		tail = node
+	}
+
+	testData := []struct {
+		drt             DagRunTask
+		status          dag.TaskStatus
+		shouldBeRetried bool
+	}{
+		{newDrt("start", 0), dag.TaskSuccess, false},
+		{newDrt("t1", 0), dag.TaskRunning, false},
+		{newDrt("t2", 0), dag.TaskFailed, true},
+		{newDrt("t2", 0), dag.TaskSuccess, false},
+		{newDrt("t2", 5), dag.TaskFailed, true},
+		{newDrt("t2", 5), dag.TaskRunning, false},
+		{newDrt("t2", 5), dag.TaskSuccess, false},
+		{newDrt("t2", 10), dag.TaskFailed, false},
+		{newDrt("t2", 10), dag.TaskScheduled, false},
+		{newDrt("t2", 10), dag.TaskRunning, false},
+		// TODO: more cases!
+	}
+
+	for _, data := range testData {
+		shouldBe, err := ftm.ShouldBeRetried(data.drt, data.status)
+		if err != nil {
+			t.Errorf("Error while ShouldBeRetried for %+v (%s): %s",
+				data.drt, data.status.String(), err.Error())
+		}
+		if shouldBe != data.shouldBeRetried {
+			t.Errorf("Expected shouldBeRetried=%v, but got %v",
+				data.shouldBeRetried, shouldBe)
+		}
+	}
+}
+
+func newFailedTaskManagerForTests(t *testing.T) *failedTaskManager {
+	dbClient, err := db.NewSqliteTmpClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dags := dag.Registry{}
+	taskQueue := ds.NewSimpleQueue[DagRunTask](100)
+	taskCache := ds.NewLruCache[DagRunTask, DagRunTaskState](100)
+	return newFailedTaskManager(
+		dags, dbClient, &taskQueue, taskCache, DefaultTaskSchedulerConfig,
+		simpleLogger(),
+	)
+}

--- a/scheduler/tasks_failed_test.go
+++ b/scheduler/tasks_failed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ppacer/core/ds"
 )
 
-func TestSchouldBeRetried(t *testing.T) {
+func TestShouldBeRetried(t *testing.T) {
 	const dagId = "linear_dag"
 	execTs := time.Now()
 	ftm := newFailedTaskManagerForTests(t)
@@ -36,6 +36,16 @@ func TestSchouldBeRetried(t *testing.T) {
 	nodes := []*dag.Node{
 		dag.NewNode(et("t1")),
 		dag.NewNode(et("t2"), dag.WithTaskRetries(10)),
+		dag.NewNode(
+			et("t3"),
+			dag.WithTaskRetries(3),
+			dag.WithTaskRetriesDelay(30*time.Second),
+		),
+		dag.NewNode(
+			et("t4"),
+			dag.WithTaskRetries(2),
+			dag.WithTaskRetriesDelay(150*time.Millisecond),
+		),
 		// TODO: more nodes
 	}
 
@@ -46,25 +56,27 @@ func TestSchouldBeRetried(t *testing.T) {
 	}
 
 	testData := []struct {
-		drt             DagRunTask
-		status          dag.TaskStatus
-		shouldBeRetried bool
+		drt              DagRunTask
+		status           dag.TaskStatus
+		shouldBeRetried  bool
+		delayBeforeRetry float64
 	}{
-		{newDrt("start", 0), dag.TaskSuccess, false},
-		{newDrt("t1", 0), dag.TaskRunning, false},
-		{newDrt("t2", 0), dag.TaskFailed, true},
-		{newDrt("t2", 0), dag.TaskSuccess, false},
-		{newDrt("t2", 5), dag.TaskFailed, true},
-		{newDrt("t2", 5), dag.TaskRunning, false},
-		{newDrt("t2", 5), dag.TaskSuccess, false},
-		{newDrt("t2", 10), dag.TaskFailed, false},
-		{newDrt("t2", 10), dag.TaskScheduled, false},
-		{newDrt("t2", 10), dag.TaskRunning, false},
-		// TODO: more cases!
+		{newDrt("start", 0), dag.TaskSuccess, false, 0},
+		{newDrt("t1", 0), dag.TaskRunning, false, 0},
+		{newDrt("t2", 0), dag.TaskFailed, true, 0},
+		{newDrt("t2", 0), dag.TaskSuccess, false, 0},
+		{newDrt("t2", 5), dag.TaskFailed, true, 0},
+		{newDrt("t2", 5), dag.TaskRunning, false, 0},
+		{newDrt("t2", 5), dag.TaskSuccess, false, 0},
+		{newDrt("t2", 10), dag.TaskFailed, false, 0},
+		{newDrt("t2", 10), dag.TaskScheduled, false, 0},
+		{newDrt("t2", 10), dag.TaskRunning, false, 0},
+		{newDrt("t3", 0), dag.TaskFailed, true, 30.0},
+		{newDrt("t4", 0), dag.TaskFailed, true, 0.150},
 	}
 
 	for _, data := range testData {
-		shouldBe, err := ftm.ShouldBeRetried(data.drt, data.status)
+		shouldBe, delay, err := ftm.ShouldBeRetried(data.drt, data.status)
 		if err != nil {
 			t.Errorf("Error while ShouldBeRetried for %+v (%s): %s",
 				data.drt, data.status.String(), err.Error())
@@ -72,6 +84,10 @@ func TestSchouldBeRetried(t *testing.T) {
 		if shouldBe != data.shouldBeRetried {
 			t.Errorf("Expected shouldBeRetried=%v, but got %v",
 				data.shouldBeRetried, shouldBe)
+		}
+		if delay.Seconds() != data.delayBeforeRetry {
+			t.Errorf("Expected delayBeforeRetry=%v, got: %v",
+				data.delayBeforeRetry, delay)
 		}
 	}
 }

--- a/scheduler/tasks_test.go
+++ b/scheduler/tasks_test.go
@@ -90,7 +90,7 @@ func TestScheduleSingleTaskSimple(t *testing.T) {
 	}
 
 	// Task's status should be cached
-	cacheStatus, existInCache := ts.taskCache.Get(drt.WithNoRetry())
+	cacheStatus, existInCache := ts.taskCache.Get(drt.Base())
 	if !existInCache {
 		t.Errorf("Scheduled task %v does not exist in TaskCache", drt)
 	}
@@ -193,7 +193,7 @@ func TestWalkAndScheduleOnAsyncTasks(t *testing.T) {
 	// be Scheduled.
 	testTaskCacheQueueTableSize(ts, 4, t)
 	testTaskStatusInCache(ts, drtN21, dag.TaskScheduled, t)
-	if _, n3Exists := ts.taskCache.Get(drtN3.WithNoRetry()); n3Exists {
+	if _, n3Exists := ts.taskCache.Get(drtN3.Base()); n3Exists {
 		t.Errorf("Unexpectedly %+v exists in TaskCache before n21, n22, n23 finished",
 			drtN3)
 	}
@@ -211,7 +211,7 @@ func TestWalkAndScheduleOnAsyncTasks(t *testing.T) {
 	testTaskStatusInDB(ts, drtN21, dag.TaskScheduled, t)
 	testTaskStatusInCache(ts, drtN22, dag.TaskSuccess, t)
 	testTaskStatusInDB(ts, drtN22, dag.TaskSuccess, t)
-	if _, n3Exists := ts.taskCache.Get(drtN3.WithNoRetry()); n3Exists {
+	if _, n3Exists := ts.taskCache.Get(drtN3.Base()); n3Exists {
 		t.Errorf("Unexpectedly %+v exists in TaskCache before n21, n22, n23 finished",
 			drtN3)
 	}
@@ -824,7 +824,7 @@ func TestCheckIfAlreadyFinishedInCache(t *testing.T) {
 	for _, d := range data {
 		drt := DagRunTask{dagrun.DagId, dagrun.AtTime, d.taskId, 0}
 		status := DagRunTaskState{d.expectedStatus, dagrun.AtTime.Add(1 * time.Second)}
-		ts.taskCache.Put(drt.WithNoRetry(), status)
+		ts.taskCache.Put(drt.Base(), status)
 
 		isFinished, tStatus := ts.checkIfAlreadyFinished(dagrun, d.taskId)
 		testAlreadyFinishedTaskExpectedStatus(
@@ -893,7 +893,7 @@ func TestGetDagRunTaskStatusFromCache(t *testing.T) {
 	dagrun := DagRun{dag.Id("mock_dag"), time.Now()}
 	drt := DagRunTask{dagrun.DagId, dagrun.AtTime, taskId, 0}
 	status := DagRunTaskState{dag.TaskSuccess, dagrun.AtTime}
-	ts.taskCache.Put(drt.WithNoRetry(), status)
+	ts.taskCache.Put(drt.Base(), status)
 
 	// Get dag run task status
 	statusNew, getErr := ts.getDagRunTaskStatus(dagrun, taskId)
@@ -941,7 +941,7 @@ func TestGetDagRunTaskStatusFromDatabase(t *testing.T) {
 	}
 
 	// Check if this dag run task is also in the cache
-	drts, exists := ts.taskCache.Get(drt.WithNoRetry())
+	drts, exists := ts.taskCache.Get(drt.Base())
 	if !exists {
 		t.Errorf("Expected %v to exist in the task cache, but it's not",
 			drt)
@@ -1054,7 +1054,7 @@ func testTaskStatusInCache(
 	expectedStatus dag.TaskStatus,
 	t *testing.T,
 ) {
-	drts, exists := ts.taskCache.Get(drt.WithNoRetry())
+	drts, exists := ts.taskCache.Get(drt.Base())
 	if !exists {
 		t.Errorf("Cannot get %+v from the TaskCache", drt)
 	}
@@ -1103,7 +1103,7 @@ func defaultTaskScheduler(t *testing.T, taskQueueCap int) *TaskScheduler {
 		DagRuns:     &drQueue,
 		DagRunTasks: &taskQueue,
 	}
-	taskCache := ds.NewLruCache[DagRunTask, DagRunTaskState](10)
+	taskCache := ds.NewLruCache[DRTBase, DagRunTaskState](10)
 	getStateFunc := func() State {
 		return StateRunning
 	}


### PR DESCRIPTION
In this rather lengthy PR we are introducing mechanism for restarting failed DAG run tasks.
Most important high-level changes:

- Number of retries and possibly time delay before the next retry is a part of dag.Node configuration in `dag.TaskConfig`.
- By default tasks are not retried (`TaskConfig.Retries = 0`). Also default time delay before scheduling the next retry is set to `0` seconds.
- Schemas for the ppacer database and task logs database has been extended by `Retry` column in `dagruntasks` table.
- `TaskScheduler` has been adjusted to handle retries as expected. Also all fields of `scheduler.TaskScheduler` are now private and the type has constructor function - `scheduler.NewTaskScheduler`.
- `TaskCache` stores information about the status of the latest DAG run task execution. We introduced new type `DRTBase`, to exclude `Retry` field from `DagRunTask` type to avoid confusions.
