### PR TITLE
Introduce cap for number of goroutines spawned by Scheduler and Executor

### DIFF
--- a/dag/task.go
+++ b/dag/task.go
@@ -133,7 +133,7 @@ type Node struct {
 // custom configuration a set of TaskConfigFunc can be passed. For example:
 //
 //	var t Task = T()
-//	n1 := NewNode(t, WithTaskTimeout(30), WithTaskRetries(3))
+//	n1 := NewNode(t, WithTaskTimeout(30 * time.Second), WithTaskRetries(3))
 //
 //	var t2 Task = T2()
 //	n2 := NewNode(t2, func(config *TaskConfig) {

--- a/e2etests/dags.go
+++ b/e2etests/dags.go
@@ -16,6 +16,15 @@ import (
 	"github.com/ppacer/core/notify"
 )
 
+func singleEmptyTaskDag(dagId dag.Id, sched schedule.Schedule) dag.Dag {
+	root := dag.NewNode(emptyTask{taskId: "root"})
+	return dag.New(dagId).
+		AddRoot(root).
+		AddAttributes(dag.Attr{CatchUp: false}).
+		AddSchedule(sched).
+		Done()
+}
+
 func simple131DAG(dagId dag.Id, sched *schedule.Schedule) dag.Dag {
 	n1 := dag.NewNode(emptyTask{taskId: "n1"})
 	n21 := dag.NewNode(emptyTask{taskId: "n21"})
@@ -24,9 +33,9 @@ func simple131DAG(dagId dag.Id, sched *schedule.Schedule) dag.Dag {
 	n3 := dag.NewNode(emptyTask{taskId: "n3"})
 	n1.NextAsyncAndMerge([]*dag.Node{n21, n22, n23}, n3)
 
-	d := dag.New(dagId)
-	d.AddRoot(n1)
-	d.AddAttributes(dag.Attr{CatchUp: false})
+	d := dag.New(dagId).
+		AddRoot(n1).
+		AddAttributes(dag.Attr{CatchUp: false})
 
 	if sched != nil {
 		d.AddSchedule(*sched)

--- a/e2etests/simple_test.go
+++ b/e2etests/simple_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestSchedulerE2eSimpleDagEmptyTasks(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -33,12 +32,11 @@ func TestSchedulerE2eSimpleDagEmptyTasks(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, true, &notifications, t,
 	)
 }
 
 func TestSchedulerE2eSimpleDagEmptyTasksNoSched(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	dagId := dag.Id("mock_dag_1")
 	dags.Add(simple131DAG(dagId, nil))
@@ -47,12 +45,11 @@ func TestSchedulerE2eSimpleDagEmptyTasksNoSched(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, true, &notifications, t,
 	)
 }
 
 func TestSchedulerE2eLinkedListEmptyTask(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -64,12 +61,11 @@ func TestSchedulerE2eLinkedListEmptyTask(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, true, &notifications, t,
 	)
 }
 
 func TestSchedulerE2eLinkedListWaitTask(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -81,12 +77,11 @@ func TestSchedulerE2eLinkedListWaitTask(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, true, &notifications, t,
 	)
 }
 
 func TestSchedulerE2eSimpleDagWithErrTask(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -97,7 +92,7 @@ func TestSchedulerE2eSimpleDagWithErrTask(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, false, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, false, &notifications, t,
 	)
 
 	if len(notifications) == 0 {
@@ -110,7 +105,6 @@ func TestSchedulerE2eSimpleDagWithErrTask(t *testing.T) {
 }
 
 func TestSchedulerE2eSimpleDagWithErrTaskCustomNotifier(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -123,7 +117,7 @@ func TestSchedulerE2eSimpleDagWithErrTaskCustomNotifier(t *testing.T) {
 	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, false, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, false, &notifications, t,
 	)
 
 	if len(notifications) == 0 {
@@ -138,7 +132,6 @@ func TestSchedulerE2eSimpleDagWithErrTaskCustomNotifier(t *testing.T) {
 }
 
 func TestSchedulerE2eSimpleDagWithRuntimeErrTask(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -149,7 +142,7 @@ func TestSchedulerE2eSimpleDagWithRuntimeErrTask(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, false, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, false, &notifications, t,
 	)
 
 	if len(notifications) == 0 {
@@ -158,7 +151,6 @@ func TestSchedulerE2eSimpleDagWithRuntimeErrTask(t *testing.T) {
 }
 
 func TestSchedulerE2eTwoDagRunsSameTimeSameSchedule(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	notifications := make([]string, 0)
 
@@ -180,11 +172,12 @@ func TestSchedulerE2eTwoDagRunsSameTimeSameSchedule(t *testing.T) {
 	}
 
 	testSchedulerE2eManyDagRuns(
-		dags, drs, 3*time.Second, true, &notifications, dbClient, t,
+		dags, drs, 3*time.Second, true, &notifications, t,
 	)
 }
 
 func TestSchedulerE2eWritingLogsToSQLite(t *testing.T) {
+	// TODO: I'm almost sure this test can be simplifed
 	cfg := scheduler.DefaultConfig
 	queues := scheduler.DefaultQueues(cfg)
 	notifications := make([]string, 0)
@@ -200,7 +193,7 @@ func TestSchedulerE2eWritingLogsToSQLite(t *testing.T) {
 
 	// Start scheduler
 	sched, dbClient, logsDbClient := schedulerWithSqlite(
-		queues, cfg, &notifications, nil, t,
+		queues, cfg, &notifications, nil, nil, t,
 	)
 	testServer := httptest.NewServer(sched.Start(dags))
 	defer testServer.Close()
@@ -239,39 +232,42 @@ func TestSchedulerE2eWritingLogsToSQLite(t *testing.T) {
 // (dbClient) might be nil - in this case standard SqliteTmpClient would be
 // used.
 func testSchedulerE2eSingleDagRun(
-	dags dag.Registry, dr scheduler.DagRun, timeout time.Duration,
-	expectSuccess bool, notifications *[]string, dbClient *db.Client,
+	dags dag.Registry,
+	dr scheduler.DagRun,
+	timeout time.Duration,
+	expectSuccess bool,
+	notifications *[]string,
 	t *testing.T,
 ) {
 	t.Helper()
 	drs := []scheduler.DagRun{dr}
 	testSchedulerE2eManyDagRuns(
-		dags, drs, timeout, expectSuccess, notifications, dbClient, t,
+		dags, drs, timeout, expectSuccess, notifications, t,
 	)
 }
 
 func testSchedulerE2eManyDagRuns(
-	dags dag.Registry, drs []scheduler.DagRun, timeout time.Duration,
-	expectSuccess bool, notifications *[]string, dbClient *db.Client,
+	dags dag.Registry,
+	drs []scheduler.DagRun,
+	timeout time.Duration,
+	expectSuccess bool,
+	notifications *[]string,
 	t *testing.T,
 ) {
 	t.Helper()
 	cfg := scheduler.DefaultConfig
 	queues := scheduler.DefaultQueues(cfg)
-	notifier := notify.NewLogsErr(slog.Default())
-
-	// Start scheduler
 	sched, dbClient, logsDbClient := schedulerWithSqlite(
-		queues, cfg, notifications, dbClient, t,
+		queues, cfg, notifications, nil, nil, t,
 	)
 	testServer := httptest.NewServer(sched.Start(dags))
+
 	defer testServer.Close()
-	if dbClient == nil {
-		defer db.CleanUpSqliteTmp(dbClient, t)
-		defer db.CleanUpSqliteTmp(logsDbClient, t)
-	}
+	defer db.CleanUpSqliteTmp(dbClient, t)
+	defer db.CleanUpSqliteTmp(logsDbClient, t)
 
 	// Start executor
+	notifier := notify.NewLogsErr(slog.Default())
 	go func() {
 		executor := exec.New(testServer.URL, logsDbClient, nil, nil, notifier)
 		executor.Start(dags)
@@ -286,6 +282,82 @@ func testSchedulerE2eManyDagRuns(
 	const poll = 10 * time.Millisecond
 	for _, dr := range drs {
 		waitForDagRunCompletion(dbClient, dr, poll, timeout, expectSuccess, t)
+	}
+}
+
+func testSchedulerE2eSingleDagRunCustom(
+	dags dag.Registry,
+	dr scheduler.DagRun,
+	timeout time.Duration,
+	expectSuccess bool,
+	notifications *[]string,
+	dbClient *db.Client,
+	logsDbClient *db.Client,
+	sched *scheduler.Scheduler,
+	queues *scheduler.Queues,
+	waitForDagRun bool,
+	t *testing.T,
+) {
+	t.Helper()
+	drs := []scheduler.DagRun{dr}
+	testSchedulerE2eManyDagRunsCustom(
+		dags, drs, timeout, expectSuccess, notifications, dbClient,
+		logsDbClient, sched, queues, waitForDagRun, t,
+	)
+}
+
+func testSchedulerE2eManyDagRunsCustom(
+	dags dag.Registry,
+	drs []scheduler.DagRun,
+	timeout time.Duration,
+	expectSuccess bool,
+	notifications *[]string,
+	dbClient *db.Client,
+	logsDbClient *db.Client,
+	sched *scheduler.Scheduler,
+	queues *scheduler.Queues,
+	waitForDagRun bool,
+	t *testing.T,
+) {
+	t.Helper()
+	cfg := scheduler.DefaultConfig
+	if queues == nil {
+		q := scheduler.DefaultQueues(cfg)
+		queues = &q
+	}
+	if sched == nil {
+		sched, dbClient, logsDbClient = schedulerWithSqlite(
+			*queues, cfg, notifications, dbClient, logsDbClient, t,
+		)
+	}
+	testServer := httptest.NewServer(sched.Start(dags))
+
+	defer testServer.Close()
+	if dbClient == nil {
+		defer db.CleanUpSqliteTmp(dbClient, t)
+	}
+	if logsDbClient == nil {
+		defer db.CleanUpSqliteTmp(logsDbClient, t)
+	}
+
+	// Start executor
+	notifier := notify.NewLogsErr(slog.Default())
+	go func() {
+		executor := exec.New(testServer.URL, logsDbClient, nil, nil, notifier)
+		executor.Start(dags)
+	}()
+
+	// Schedule new DAG runs
+	for _, dr := range drs {
+		scheduleNewDagRun(dbClient, *queues, dr, t)
+	}
+
+	if waitForDagRun {
+		// Wait for DAG run completion or timeout.
+		const poll = 10 * time.Millisecond
+		for _, dr := range drs {
+			waitForDagRunCompletion(dbClient, dr, poll, timeout, expectSuccess, t)
+		}
 	}
 }
 
@@ -342,7 +414,7 @@ func scheduleNewDagRun(
 
 func schedulerWithSqlite(
 	queues scheduler.Queues, config scheduler.Config, notifications *[]string,
-	dbClient *db.Client, t *testing.T,
+	dbClient *db.Client, logsDbClient *db.Client, t *testing.T,
 ) (*scheduler.Scheduler, *db.Client, *db.Client) {
 	t.Helper()
 	if dbClient == nil {
@@ -352,9 +424,12 @@ func schedulerWithSqlite(
 			t.Fatal(err)
 		}
 	}
-	logsDbClient, lErr := db.NewSqliteTmpClientForLogs(nil)
-	if lErr != nil {
-		t.Fatal(lErr)
+	if logsDbClient == nil {
+		var lErr error
+		logsDbClient, lErr = db.NewSqliteTmpClientForLogs(nil)
+		if lErr != nil {
+			t.Fatal(lErr)
+		}
 	}
 	notifier := notify.NewMock(notifications)
 	sched := scheduler.New(dbClient, queues, config, nil, notifier)

--- a/e2etests/stress_test.go
+++ b/e2etests/stress_test.go
@@ -1,0 +1,207 @@
+package e2etests
+
+import (
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ppacer/core/dag"
+	"github.com/ppacer/core/dag/schedule"
+	"github.com/ppacer/core/db"
+	"github.com/ppacer/core/exec"
+	"github.com/ppacer/core/notify"
+	"github.com/ppacer/core/scheduler"
+)
+
+func TestMaxGoroutineManyParallelTasks(t *testing.T) {
+	const tasksCount = 100
+	const maxGoroutines = 10
+	cfg := scheduler.DefaultConfig
+	cfg.TaskSchedulerConfig.MaxGoroutineCount = maxGoroutines
+
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("many_parallel_tasks_dag")
+	dags.Add(manyParallelWaitTasksDag(dagId, schedule, tasksCount))
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+
+	drs := []scheduler.DagRun{dr}
+	testMaxGoroutineCount(dags, drs, cfg, maxGoroutines, 5*time.Second, nil, t)
+}
+
+func TestMaxGoroutineManyParallelTasksFewDagRuns(t *testing.T) {
+	const dagRuns = 4
+	const tasksCount = 50
+	const maxGoroutines = 15
+	cfg := scheduler.DefaultConfig
+	cfg.TaskSchedulerConfig.MaxGoroutineCount = maxGoroutines
+
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("many_parallel_tasks_dag")
+	dags.Add(manyParallelWaitTasksDag(dagId, schedule, tasksCount))
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+
+	drs := make([]scheduler.DagRun, dagRuns)
+	for i := 0; i < dagRuns; i++ {
+		dr := scheduler.DagRun{
+			DagId:  dagId,
+			AtTime: ts.Add(time.Duration(i) * 13 * 60 * time.Minute),
+		}
+		drs[i] = dr
+	}
+
+	testMaxGoroutineCount(dags, drs, cfg, maxGoroutines+dagRuns, 5*time.Second,
+		nil, t)
+}
+
+func TestMaxGoroutineManyDagRunsSingleTask(t *testing.T) {
+	const dagRuns = 100
+	const maxGoroutines = 10
+	cfg := scheduler.DefaultConfig
+	cfg.TaskSchedulerConfig.MaxGoroutineCount = maxGoroutines
+
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("single_task_dag")
+	dags.Add(singleEmptyTaskDag(dagId, schedule))
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+
+	drs := make([]scheduler.DagRun, dagRuns)
+	for i := 0; i < dagRuns; i++ {
+		dr := scheduler.DagRun{
+			DagId:  dagId,
+			AtTime: ts.Add(time.Duration(i) * 23 * 60 * time.Minute),
+		}
+		drs[i] = dr
+	}
+
+	testMaxGoroutineCount(dags, drs, cfg, maxGoroutines, 5*time.Second, nil, t)
+}
+
+func TestMaxGoroutineManyParallelTasksLimitedExecutor(t *testing.T) {
+	const tasksCount = 100
+	const maxGoroutines = 10
+	const executorMaxGoroutines = 5
+	cfg := scheduler.DefaultConfig
+	cfg.TaskSchedulerConfig.MaxGoroutineCount = maxGoroutines
+	execCfg := exec.Config{
+		PollInterval:       1 * time.Millisecond,
+		HttpRequestTimeout: 30 * time.Second,
+		MaxGoroutineCount:  executorMaxGoroutines,
+	}
+
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	dagId := dag.Id("many_parallel_tasks_dag")
+	dags.Add(manyParallelWaitTasksDag(dagId, schedule, tasksCount))
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+
+	drs := []scheduler.DagRun{dr}
+	testMaxGoroutineCount(dags, drs, cfg, maxGoroutines, 5*time.Second,
+		&execCfg, t)
+}
+
+func testMaxGoroutineCount(
+	dags dag.Registry,
+	drs []scheduler.DagRun,
+	cfg scheduler.Config,
+	expectedMaxGoroutines int,
+	drTimeout time.Duration,
+	executorConfig *exec.Config,
+	t *testing.T,
+) {
+	t.Helper()
+	queues := scheduler.DefaultQueues(cfg)
+	notifications := make([]string, 0)
+
+	dbClient, err := db.NewSqliteTmpClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.CleanUpSqliteTmp(dbClient, t)
+
+	sched, _, logsDbClient := schedulerWithSqlite(
+		queues, cfg, &notifications, dbClient, nil, t,
+	)
+
+	testServer := httptest.NewServer(sched.Start(dags))
+	defer testServer.Close()
+
+	// Start executor
+	notifier := notify.NewLogsErr(slog.Default())
+	go func() {
+		executor := exec.New(testServer.URL, logsDbClient, nil, nil, notifier)
+		executor.Start(dags)
+	}()
+
+	var currentMax int64
+	doneChan := make(chan struct{})
+	go func(currentMax *int64, doneChan <-chan struct{}) {
+		for {
+			select {
+			case <-doneChan:
+				return
+			default:
+				time.Sleep(1 * time.Millisecond)
+				gc := sched.Goroutines()
+				if gc > *currentMax {
+					atomic.StoreInt64(currentMax, gc)
+				}
+			}
+		}
+	}(&currentMax, doneChan)
+
+	for _, dr := range drs {
+		scheduleNewDagRun(dbClient, queues, dr, t)
+	}
+
+	// Wait for DAG run completion or timeout.
+	const poll = 10 * time.Millisecond
+	for _, dr := range drs {
+		waitForDagRunCompletion(dbClient, dr, poll, drTimeout, true, t)
+	}
+	doneChan <- struct{}{}
+
+	if currentMax <= 1 {
+		t.Errorf("Expected at least two goroutines, got %d", currentMax)
+	}
+	if currentMax > int64(expectedMaxGoroutines) {
+		t.Errorf("Expected at most %d goroutines while running Scheduler, got: %d",
+			expectedMaxGoroutines, currentMax)
+	}
+}
+
+func manyParallelWaitTasksDag(
+	dagId dag.Id, schedule schedule.Schedule, tasks int,
+) dag.Dag {
+	start := dag.NewNode(emptyTask{taskId: "start"})
+	pTasks := make([]*dag.Node, 0, tasks)
+
+	for i := 0; i < tasks; i++ {
+		id := fmt.Sprintf("task_%d", i)
+		rand := rand.Intn(200) + 400
+		node := dag.NewNode(
+			waitTask{
+				taskId:   id,
+				interval: time.Duration(rand) * time.Millisecond},
+		)
+		pTasks = append(pTasks, node)
+	}
+	finish := dag.NewNode(emptyTask{taskId: "finish"})
+
+	start.NextAsyncAndMerge(pTasks, finish)
+
+	d := dag.New(dagId).AddRoot(start).AddSchedule(schedule).Done()
+	return d
+}

--- a/e2etests/task_retries_test.go
+++ b/e2etests/task_retries_test.go
@@ -20,7 +20,6 @@ func TestSimpleDagRunWithRetries(t *testing.T) {
 	const failedRuns = 3
 	const maxRetries = 3
 
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -34,12 +33,11 @@ func TestSimpleDagRunWithRetries(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, true, &notifications, t,
 	)
 }
 
 func TestSimpleDagRunWithZeroRetries(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -53,7 +51,7 @@ func TestSimpleDagRunWithZeroRetries(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, true, &notifications, t,
 	)
 }
 
@@ -61,7 +59,6 @@ func TestSimpleDagRunWithFailureAfterRetries(t *testing.T) {
 	const failedRuns = 10
 	const maxRetries = 3
 
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -75,7 +72,7 @@ func TestSimpleDagRunWithFailureAfterRetries(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, false, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, false, &notifications, t,
 	)
 }
 
@@ -83,7 +80,6 @@ func TestSimpleDagRunWithRetriesAndAlerts(t *testing.T) {
 	const failedRuns = 3
 	const maxRetries = 5
 
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -99,7 +95,7 @@ func TestSimpleDagRunWithRetriesAndAlerts(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, true, &notifications, t,
 	)
 
 	if len(notifications) != failedRuns {
@@ -114,7 +110,6 @@ func TestSimpleDagRunWithRetriesAndAlerts(t *testing.T) {
 }
 
 func TestDagRunWithParallelRetries(t *testing.T) {
-	var dbClient *db.Client = nil
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
@@ -125,7 +120,7 @@ func TestDagRunWithParallelRetries(t *testing.T) {
 	notifications := make([]string, 0)
 
 	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+		dags, dr, 3*time.Second, true, &notifications, t,
 	)
 
 	if len(notifications) == 0 {
@@ -184,8 +179,9 @@ func TestDagRunWithDelayedRetries(t *testing.T) {
 	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
 	notifications := make([]string, 0)
 
-	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, true, &notifications, dbClient, t,
+	testSchedulerE2eSingleDagRunCustom(
+		dags, dr, 3*time.Second, true, &notifications, dbClient, nil, nil, nil,
+		true, t,
 	)
 
 	ctx := context.Background()

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -58,6 +58,9 @@ type TaskSchedulerConfig struct {
 	// How long TaskScheduler should try to put new DAG run task onto the task
 	// queue.
 	PutOnTaskQueueTimeout time.Duration
+
+	// Max number of goroutines spawned by Scheduler.
+	MaxGoroutineCount int
 }
 
 // Default taskScheduler configuration.
@@ -65,6 +68,7 @@ var DefaultTaskSchedulerConfig TaskSchedulerConfig = TaskSchedulerConfig{
 	Heartbeat:                   1 * time.Millisecond,
 	CheckDependenciesStatusWait: 1 * time.Millisecond,
 	PutOnTaskQueueTimeout:       30 * time.Second,
+	MaxGoroutineCount:           10000,
 }
 
 // Configuration for DagRunWatcher which is responsible for scheduling new DAG

--- a/scheduler/tasks_test.go
+++ b/scheduler/tasks_test.go
@@ -1110,9 +1110,10 @@ func defaultTaskScheduler(t *testing.T, taskQueueCap int) *TaskScheduler {
 	notifications := make([]string, 0)
 	notifier := notify.NewMock(&notifications)
 
+	var goroutinesCount int64
 	ts := NewTaskScheduler(
 		registry, c, queues, taskCache, DefaultTaskSchedulerConfig,
-		simpleLogger(), notifier, getStateFunc,
+		simpleLogger(), notifier, &goroutinesCount, getStateFunc,
 	)
 	return ts
 }


### PR DESCRIPTION
- `Scheduler` and in particular `TaskScheduler` won't schedule another goroutine for another task in case when number of currently running goroutines reached the level of `TaskSchedulerConfig.MaxGoroutineCount`.
- Default config sets the cap at 10k goroutines
- Similarly for `exec.Executor` but with default configuration set to 1k goroutines.