### PR TITLE
New pace package and usage of pace.LinearBackoff in Executor

### DIFF
--- a/e2etests/simple_test.go
+++ b/e2etests/simple_test.go
@@ -202,7 +202,9 @@ func TestSchedulerE2eWritingLogsToSQLite(t *testing.T) {
 
 	// Start executor
 	go func() {
-		executor := exec.New(testServer.URL, logsDbClient, nil, nil, notifier)
+		executor := exec.New(
+			testServer.URL, logsDbClient, nil, nil, nil, notifier,
+		)
 		executor.Start(dags)
 	}()
 
@@ -269,7 +271,9 @@ func testSchedulerE2eManyDagRuns(
 	// Start executor
 	notifier := notify.NewLogsErr(slog.Default())
 	go func() {
-		executor := exec.New(testServer.URL, logsDbClient, nil, nil, notifier)
+		executor := exec.New(
+			testServer.URL, logsDbClient, nil, nil, nil, notifier,
+		)
 		executor.Start(dags)
 	}()
 
@@ -343,7 +347,9 @@ func testSchedulerE2eManyDagRunsCustom(
 	// Start executor
 	notifier := notify.NewLogsErr(slog.Default())
 	go func() {
-		executor := exec.New(testServer.URL, logsDbClient, nil, nil, notifier)
+		executor := exec.New(
+			testServer.URL, logsDbClient, nil, nil, nil, notifier,
+		)
 		executor.Start(dags)
 	}()
 

--- a/e2etests/stress_test.go
+++ b/e2etests/stress_test.go
@@ -94,7 +94,6 @@ func TestMaxGoroutineManyParallelTasksLimitedExecutor(t *testing.T) {
 	cfg := scheduler.DefaultConfig
 	cfg.TaskSchedulerConfig.MaxGoroutineCount = maxGoroutines
 	execCfg := exec.Config{
-		PollInterval:       1 * time.Millisecond,
 		HttpRequestTimeout: 30 * time.Second,
 		MaxGoroutineCount:  executorMaxGoroutines,
 	}
@@ -141,7 +140,9 @@ func testMaxGoroutineCount(
 	// Start executor
 	notifier := notify.NewLogsErr(slog.Default())
 	go func() {
-		executor := exec.New(testServer.URL, logsDbClient, nil, nil, notifier)
+		executor := exec.New(
+			testServer.URL, logsDbClient, nil, nil, nil, notifier,
+		)
 		executor.Start(dags)
 	}()
 

--- a/pace/fixed.go
+++ b/pace/fixed.go
@@ -1,0 +1,24 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+package pace
+
+import "time"
+
+// Fixed implements Strategy for fixed-duration intervals. Reset methods does
+// nothing. All intervals are the same duration.
+type Fixed struct {
+	interval time.Duration
+}
+
+// NewFixed initialize new Fixed strategy for given interval duration.
+func NewFixed(interval time.Duration) *Fixed {
+	return &Fixed{interval: interval}
+}
+
+// NextInterval returns fixed interval duration every time.
+func (f *Fixed) NextInterval() time.Duration { return f.interval }
+
+// Reset does nothing for Fixed strategy.
+func (f *Fixed) Reset() {}

--- a/pace/fixed_test.go
+++ b/pace/fixed_test.go
@@ -1,0 +1,31 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+package pace
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFixed(t *testing.T) {
+	data := []time.Duration{
+		1 * time.Millisecond,
+		15 * time.Nanosecond,
+		15 * 60 * time.Second,
+	}
+
+	for _, input := range data {
+		f := NewFixed(input)
+		if next := f.NextInterval(); next != input {
+			t.Errorf("Expected NextInterval %v, got: %v",
+				input, next)
+		}
+		f.Reset()
+		if next := f.NextInterval(); next != input {
+			t.Errorf("Expected NextInterval %v, got: %v",
+				input, next)
+		}
+	}
+}

--- a/pace/linear.go
+++ b/pace/linear.go
@@ -1,0 +1,85 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+package pace
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// LinearBackoff implements Strategy for linear back off with possible
+// repetitions. Intervals starts at min, are repeated repeat times, then
+// increases duration to (min + step) and are again repeated repeat times.
+// Those increments continues until we reach max duration. Intervals stays at
+// max duration until the next Reset() call.
+//
+// Example for min=1ms, max=1s (1000ms), step=250ms and repeat=2.
+// Consecutive calls to NextInterval() would return the following sequence:
+//
+//	1ms, 1ms, 251ms, 251ms, 501ms, 501ms, 1000ms, 1000ms, ... (until Reset),
+//	1000ms
+//
+// For more gradual increases (min=0ms, max=1s, step=10ms and repeat=1):
+//
+//	0ms, 10ms, 20ms, 30ms, ..., 980ms, 990ms, 1000ms, 1000ms, 1000ms, ...
+//
+// Cumulative duration from the beginning to reach the first max value (1s)
+// takes around 50 seconds.
+type LinearBackoff struct {
+	min    time.Duration
+	max    time.Duration
+	step   time.Duration
+	repeat int
+
+	current     time.Duration
+	repeatCount int
+}
+
+// NewLinearBackoff initialize new LinearBackoff strategy. All durations (min,
+// max and step) should be positive and max needs to be greater than min.
+// Otherwise non-nil error will be returned. Parameter repeat needs to be at
+// least 1.
+func NewLinearBackoff(min, max, step time.Duration, repeat int) (*LinearBackoff, error) {
+	if min < 0 || max < 0 || step < 0 {
+		return nil, errors.New("min, max, step durations should be positive")
+	}
+	if max <= min {
+		return nil, fmt.Errorf("max should be greater than min (min:%v, max:%v)",
+			min, max)
+	}
+	if repeat < 1 {
+		return nil, errors.New("repeat needs to be at least 1")
+	}
+
+	return &LinearBackoff{
+		min:     min,
+		max:     max,
+		step:    step,
+		repeat:  repeat,
+		current: min,
+	}, nil
+}
+
+// NextInterval returns time duration, to pass before the next event.
+func (lb *LinearBackoff) NextInterval() time.Duration {
+	if lb.repeatCount < lb.repeat {
+		lb.repeatCount++
+	} else {
+		lb.repeatCount = 1
+		lb.current += lb.step
+		if lb.current > lb.max {
+			lb.current = lb.max
+		}
+	}
+	return lb.current
+}
+
+// Reset resets internal LinearBackoff state. In particular next call to
+// NextInterval should return min duration interval.
+func (lb *LinearBackoff) Reset() {
+	lb.current = lb.min
+	lb.repeatCount = 0
+}

--- a/pace/linear_test.go
+++ b/pace/linear_test.go
@@ -1,0 +1,242 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+package pace
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	u  = 1 * time.Microsecond
+	ms = 1 * time.Millisecond
+	s  = 1 * time.Second
+)
+
+func TestNewLinearBackoff(t *testing.T) {
+	data := []struct {
+		min           time.Duration
+		max           time.Duration
+		step          time.Duration
+		repeat        int
+		expectedError bool
+	}{
+		{10 * ms, 100 * ms, 10 * ms, 1, false},
+		{10 * ms, 100 * ms, 10 * ms, 0, true},
+		{10 * ms, 100 * ms, 10 * ms, -123, true},
+		{0 * ms, 100 * ms, 1 * time.Microsecond, 1, false},
+		{10 * ms, 100 * ms, 10 * ms, 10, false},
+
+		{100 * s, 10 * s, s, 1, true},
+		{1 * s, -10 * s, -s, 10, true},
+	}
+
+	for _, d := range data {
+		_, err := NewLinearBackoff(d.min, d.max, d.step, d.repeat)
+		if err != nil && !d.expectedError {
+			t.Errorf(
+				"Not expected error for NewLinearBackoff(%v, %v, %v, %d), got: %v",
+				d.min, d.max, d.step, d.repeat, err,
+			)
+		}
+		if err == nil && d.expectedError {
+			t.Errorf(
+				"Expected non-nil error for NewLinearBackoff(%v, %v, %v, %d), got nil",
+				d.min, d.max, d.step, d.repeat,
+			)
+		}
+	}
+}
+
+func TestLinearBackoffRepeat1(t *testing.T) {
+	min := 1 * ms
+	max := 100 * ms
+	step := 5 * ms
+
+	lb, err := NewLinearBackoff(min, max, step, 1)
+	if err != nil {
+		t.Errorf("Failed while initializing LinearBackoff: %s", err.Error())
+	}
+
+	first := lb.NextInterval()
+	second := lb.NextInterval()
+	for i := 0; i < 12; i++ {
+		lb.NextInterval()
+	}
+	fifteenth := lb.NextInterval()
+
+	for i := 0; i < 1000; i++ {
+		lb.NextInterval()
+	}
+	overThousand := lb.NextInterval()
+
+	// asserts
+	if first != min {
+		t.Errorf("Expected the first interval to be %v, got: %v", min, first)
+	}
+
+	expSecond := 6 * ms
+	if second != expSecond {
+		t.Errorf("Expected the second interval to be %v, got: %v", expSecond,
+			second)
+	}
+
+	expFifteenth := 71 * ms
+	if fifteenth != expFifteenth {
+		t.Errorf("Expected 15th interval to be %v, got: %v", expFifteenth,
+			fifteenth)
+	}
+
+	if overThousand != max {
+		t.Errorf("Expected >1000th interval, to be max (%v), got: %v", max,
+			overThousand)
+	}
+
+	// Reset and assert
+	lb.Reset()
+	if next := lb.NextInterval(); next != min {
+		t.Errorf("Expected the next interval after reset, to be %v, got: %v",
+			min, next)
+	}
+}
+
+func TestLinearBackoffRepeat1Monotonicity(t *testing.T) {
+	const repeat = 1
+	data := []struct {
+		min        time.Duration
+		max        time.Duration
+		step       time.Duration
+		iterations int
+	}{
+		{0, 100 * ms, 1 * ms, 2},
+		{0, 100 * ms, 1 * ms, 100},
+		{0, 100 * ms, 1 * ms, 200},
+		{1 * u, 1 * ms, 17 * u, 5},
+		{1 * u, 1 * ms, 17 * u, 100},
+		{1 * u, 1 * ms, 17 * u, 650},
+		{1 * s, 2 * s, 650 * ms, 2},
+		{1 * s, 2 * s, 650 * ms, 5},
+		{1 * s, 2 * s, 10 * s, 2},
+		{1 * s, 2 * s, 10 * s, 5},
+	}
+
+	for _, d := range data {
+		lb, newErr := NewLinearBackoff(d.min, d.max, d.step, repeat)
+		if newErr != nil {
+			t.Errorf("Error while initializing LinearBackoff(%v, %v, %v, %d): %s",
+				d.min, d.max, d.step, repeat, newErr.Error())
+			continue
+		}
+		prev := lb.NextInterval()
+		for i := 0; i < d.iterations-1; i++ {
+			curr := lb.NextInterval()
+			isMonotonic := curr == d.max || prev < curr
+			if !isMonotonic {
+				t.Errorf("Found non-monotonic intervals: id=%d prev=%v curr=%v",
+					i, prev, curr)
+			}
+			prev = curr
+		}
+	}
+}
+
+func TestLinearBackoffFlatoutAtMax(t *testing.T) {
+	data := []struct {
+		min         time.Duration
+		max         time.Duration
+		step        time.Duration
+		repeat      int
+		intervalNum int
+		expectedMax bool
+	}{
+		// repeat = 1
+		{0, 100 * ms, 1 * ms, 1, 100, false},
+		{0, 100 * ms, 1 * ms, 1, 101, true},
+		{0, 100 * ms, 1 * ms, 1, 2500, true},
+		{10 * u, 1 * s, 1 * ms, 1, 990, false},
+		{10 * u, 1 * s, 1 * ms, 1, 1001, true},
+		{10 * u, 1 * s, 1 * ms, 1, 5000, true},
+		{1 * s, 1500 * ms, 2 * s, 1, 1, false},
+		{1 * s, 1500 * ms, 2 * s, 1, 2, true},
+
+		// repeat > 1
+		{0, 100 * ms, 1 * ms, 3, 100, false},
+		{0, 100 * ms, 1 * ms, 3, 300, false},
+		{0, 100 * ms, 1 * ms, 3, 301, true},
+		{0, 100 * ms, 1 * ms, 3, 1000, true},
+		{1 * s, 1500 * ms, 2 * s, 3, 1, false},
+		{1 * s, 1500 * ms, 2 * s, 3, 3, false},
+		{1 * s, 1500 * ms, 2 * s, 3, 4, true},
+		{1 * s, 1500 * ms, 2 * s, 3, 6, true},
+		{1 * s, 1500 * ms, 2 * s, 3, 1000, true},
+
+		// repeat = 1000
+		{0, 100 * ms, 1 * ms, 1000, 1, false},
+		{0, 100 * ms, 1 * ms, 1000, 1000, false},
+		{0, 100 * ms, 1 * ms, 1000, 100 * 1000, false},
+		{0, 100 * ms, 1 * ms, 1000, 100*1000 + 1, true},
+	}
+
+	for _, d := range data {
+		lb, newErr := NewLinearBackoff(d.min, d.max, d.step, d.repeat)
+		if newErr != nil {
+			t.Errorf("Error while initializing LinearBackoff(%v, %v, %v, %d): %s",
+				d.min, d.max, d.step, d.repeat, newErr.Error())
+			continue
+		}
+		for i := 0; i < d.intervalNum-1; i++ {
+			lb.NextInterval()
+		}
+		targetInterval := lb.NextInterval()
+
+		if d.expectedMax && targetInterval != d.max {
+			t.Errorf("Expected %dth interval to be max=%v, got: %v",
+				d.intervalNum, d.max, targetInterval)
+		}
+		if !d.expectedMax && targetInterval == d.max {
+			t.Errorf("Expected %dth interval to not reach max=%v, got: %v",
+				d.intervalNum, d.max, targetInterval)
+		}
+	}
+}
+
+func TestLinearBackoffResets(t *testing.T) {
+	data := []struct {
+		min                    time.Duration
+		max                    time.Duration
+		step                   time.Duration
+		repeat                 int
+		intervalNumBeforeReset int
+	}{
+		{0, 100 * ms, 1 * ms, 1, 1},
+		{0, 100 * ms, 1 * ms, 1, 100},
+		{0, 100 * ms, 1 * ms, 100, 100},
+		{99 * u, 1 * ms, 1 * u, 1, 1},
+		{99 * u, 1 * ms, 1 * u, 1, 2},
+		{99 * u, 1 * ms, 1 * u, 1, 14},
+		{99 * u, 1 * ms, 1 * u, 1, 100},
+		{99 * u, 1 * ms, 1 * u, 13, 1},
+		{99 * u, 1 * ms, 1 * u, 13, 2},
+		{99 * u, 1 * ms, 1 * u, 13, 14},
+		{99 * u, 1 * ms, 1 * u, 13, 100},
+	}
+
+	for _, d := range data {
+		lb, newErr := NewLinearBackoff(d.min, d.max, d.step, d.repeat)
+		if newErr != nil {
+			t.Errorf("Error while initializing LinearBackoff(%v, %v, %v, %d): %s",
+				d.min, d.max, d.step, d.repeat, newErr.Error())
+			continue
+		}
+		for i := 0; i < d.intervalNumBeforeReset; i++ {
+			lb.NextInterval()
+		}
+		lb.Reset()
+		if next := lb.NextInterval(); next != d.min {
+			t.Errorf("Expected next interval after Reset, to be min=%v, got: %v",
+				d.min, next)
+		}
+	}
+}

--- a/pace/pace.go
+++ b/pace/pace.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+// Package pace provides strategies for controlling the pace of events.
+//
+// The pace package defines an interface for strategies that control the
+// interval between events, allowing for adaptive pacing based on dynamic
+// conditions. This can be useful for scenarios such as adaptive polling,
+// rate limiting, or other forms of throttling.
+package pace
+
+import "time"
+
+// Strategy defines an interface for adaptive pacing strategies.
+//
+// Implementations of the Strategy interface are used to control the interval
+// between events in a dynamic and adaptable manner. This can be particularly
+// useful in scenarios such as adaptive polling, rate limiting, and other
+// forms of event pacing where the timing between events needs to be adjusted
+// based on specific conditions.
+//
+// NextInterval method returns the duration to wait before the next event
+// should occur. The interval can adapt based on the specific implementation's
+// logic, allowing for flexible pacing strategies.
+//
+// Reset resets the pacing strategy to its initial state. This is typically
+// called when an event of interest occurs, and the pacing strategy needs to
+// restart its interval calculation from the beginning.
+type Strategy interface {
+	NextInterval() time.Duration
+	Reset()
+}

--- a/scheduler/tasks_test.go
+++ b/scheduler/tasks_test.go
@@ -358,7 +358,7 @@ func TestScheduleDagTasksLinkedListShortQueue(t *testing.T) {
 		Done()
 	dagrun := DagRun{DagId: d.Id, AtTime: schedule.Next(startTs, nil)}
 	testScheduleDagTasksSingleDagrun(
-		d, dagrun, 10*time.Millisecond, taskQueueSize, t,
+		d, dagrun, 50*time.Millisecond, taskQueueSize, t,
 	)
 }
 
@@ -415,7 +415,7 @@ func testScheduleDagTasksLinkedList(size int, t *testing.T) {
 		Done()
 	dagrun := DagRun{DagId: d.Id, AtTime: schedule.Next(startTs, nil)}
 	testScheduleDagTasksSingleDagrun(
-		d, dagrun, 10*time.Millisecond, size, t,
+		d, dagrun, 50*time.Millisecond, size, t,
 	)
 }
 


### PR DESCRIPTION
- Introducing `ppacer/core/pace` package which defines abstraction for strategies for controlling the pace of events.
- Implement `pace.Fixed` and `pace.LinearBackoff` strategies.
- Use `pace.LinearBackoff` in `exec.Executor` as adaptive polling of `Scheduler`. 