### PR TITLE
Add configuration for timezones

### DIFF
--- a/dag/tasklog/sqlite.go
+++ b/dag/tasklog/sqlite.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"time"
 	"unsafe"
 
 	"github.com/ppacer/core/db"
@@ -123,7 +122,7 @@ func (s *sqliteLogWriter) Write(p []byte) (int, error) {
 		ExecTs:     timeutils.ToString(s.ti.ExecTs),
 		TaskId:     s.ti.TaskId,
 		Retry:      s.ti.Retry,
-		InsertTs:   timeutils.ToString(time.Now()),
+		InsertTs:   timeutils.ToString(timeutils.Now()),
 		Level:      lvl,
 		Message:    msg,
 		Attributes: string(fieldsJson),

--- a/db/dag.go
+++ b/db/dag.go
@@ -47,7 +47,7 @@ func (c *Client) ReadDag(ctx context.Context, dagId string) (Dag, error) {
 // but something to consider in the future.
 func (c *Client) UpsertDag(ctx context.Context, d dag.Dag) error {
 	start := time.Now()
-	insertTs := timeutils.ToString(time.Now())
+	insertTs := timeutils.ToString(timeutils.Now())
 	dagId := string(d.Id)
 	c.logger.Debug("Start upserting dag in dags table...", "dagId", dagId,
 		"insertTs", insertTs)

--- a/db/dagruns.go
+++ b/db/dagruns.go
@@ -78,7 +78,7 @@ func (c *Client) ReadDagRuns(ctx context.Context, dagId string, topN int) ([]Dag
 // for just inserted dag run is returned or -1 in case when error is not nil.
 func (c *Client) InsertDagRun(ctx context.Context, dagId, execTs string) (int64, error) {
 	start := time.Now()
-	insertTs := timeutils.ToString(time.Now())
+	insertTs := timeutils.ToString(timeutils.Now())
 	c.logger.Debug("Start inserting dag run", "dagId", dagId, "execTs", insertTs)
 	res, err := c.dbConn.ExecContext(
 		ctx, c.insertDagRunQuery(),
@@ -136,7 +136,7 @@ func (c *Client) UpdateDagRunStatus(
 	ctx context.Context, runId int64, status string,
 ) error {
 	start := time.Now()
-	updateTs := timeutils.ToString(time.Now())
+	updateTs := timeutils.ToString(timeutils.Now())
 	c.logger.Debug("Start updating dag run status", "runId", runId)
 	res, err := c.dbConn.ExecContext(
 		ctx, c.updateDagRunStatusQuery(), status, updateTs, runId,
@@ -166,7 +166,7 @@ func (c *Client) UpdateDagRunStatusByExecTs(
 	ctx context.Context, dagId, execTs, status string,
 ) error {
 	start := time.Now()
-	updateTs := timeutils.ToString(time.Now())
+	updateTs := timeutils.ToString(timeutils.Now())
 	c.logger.Debug("Start updating dag run status by execTs", "dagId", dagId,
 		"execTs", execTs, "status", status)
 	res, err := c.dbConn.ExecContext(

--- a/db/dagruns_test.go
+++ b/db/dagruns_test.go
@@ -20,7 +20,7 @@ func TestInsertDagRunSimple(t *testing.T) {
 	}
 	ctx := context.Background()
 	dagId := "mock_dag"
-	execTs := timeutils.ToString(time.Now())
+	execTs := timeutils.ToString(timeutils.Now())
 	runId, iErr := c.InsertDagRun(ctx, dagId, execTs)
 	if iErr != nil {
 		t.Errorf("Error while inserting dag run: %s", iErr.Error())
@@ -34,7 +34,7 @@ func TestInsertDagRunSimple(t *testing.T) {
 		t.Errorf("Expected 1 row got: %d", c1)
 	}
 
-	execTs = timeutils.ToString(time.Now())
+	execTs = timeutils.ToString(timeutils.Now())
 	runId, iErr = c.InsertDagRun(ctx, dagId, execTs)
 	if iErr != nil {
 		t.Errorf("Error while inserting dag run: %s", iErr.Error())
@@ -406,7 +406,9 @@ func TestDagRunUpdateStatusByExecTsNoRun(t *testing.T) {
 	// There is no dagruns rows at all at this point
 	ctx := context.Background()
 	const status = "TEST_STATUS"
-	uErr := c.UpdateDagRunStatusByExecTs(ctx, "test_dag", timeutils.ToString(time.Now()), status)
+	uErr := c.UpdateDagRunStatusByExecTs(
+		ctx, "test_dag", timeutils.ToString(timeutils.Now()), status,
+	)
 	if uErr == nil {
 		t.Error("Expected non-empty error while updating dag run state for non existing runId")
 	}
@@ -504,7 +506,7 @@ func TestDagRunsNotFinishedForTerminalStates(t *testing.T) {
 	const dagId = "mock_dag"
 	const N = 10
 	ctx := context.Background()
-	t0 := time.Now()
+	t0 := timeutils.Now()
 
 	for i := 0; i < N; i++ {
 		ts := timeutils.ToString(t0.Add(time.Duration(i) * time.Hour))
@@ -538,7 +540,7 @@ func TestDagRunsNotFinishedForRunningStates(t *testing.T) {
 	const dagId = "mock_dag"
 	const N = 10
 	ctx := context.Background()
-	t0 := time.Now()
+	t0 := timeutils.Now()
 
 	for i := 0; i < N; i++ {
 		ts := timeutils.ToString(t0.Add(time.Duration(i) * time.Hour))

--- a/db/dagruntasks.go
+++ b/db/dagruntasks.go
@@ -69,7 +69,7 @@ func (c *Client) ReadDagRunTasks(ctx context.Context, dagId, execTs string) ([]D
 // Inserts new DagRunTask with default status SCHEDULED.
 func (c *Client) InsertDagRunTask(ctx context.Context, dagId, execTs, taskId string, retry int, status string) error {
 	start := time.Now()
-	insertTs := timeutils.ToString(start)
+	insertTs := timeutils.ToString(timeutils.Now())
 	c.logger.Debug("Start inserting new dag run task", "dagId", dagId, "execTs",
 		execTs, "taskId", taskId, "retry", retry)
 	_, iErr := c.dbConn.ExecContext(
@@ -162,7 +162,7 @@ func (c *Client) ReadDagRunTaskLatest(ctx context.Context, dagId, execTs, taskId
 // Updates dagruntask status for given dag run task.
 func (c *Client) UpdateDagRunTaskStatus(ctx context.Context, dagId, execTs, taskId string, retry int, status string) error {
 	start := time.Now()
-	updateTs := timeutils.ToString(time.Now())
+	updateTs := timeutils.ToString(timeutils.Now())
 	c.logger.Debug("Start updating dag run task status", "dagId", dagId, "execTs",
 		execTs, "taskId", taskId, "status", status)
 	res, err := c.dbConn.ExecContext(

--- a/db/dagruntasks_test.go
+++ b/db/dagruntasks_test.go
@@ -22,7 +22,7 @@ func TestInsertDagRunTaskSimple(t *testing.T) {
 	}
 	ctx := context.Background()
 	dagId := "mock_dag"
-	execTs := timeutils.ToString(time.Now())
+	execTs := timeutils.ToString(timeutils.Now())
 	taskId := "my_task_1"
 	iErr := c.InsertDagRunTask(
 		ctx, dagId, execTs, taskId, 0, DagRunTaskStatusScheduled,
@@ -74,7 +74,7 @@ func TestReadDagRunTasks(t *testing.T) {
 	}
 	ctx := context.Background()
 	dagId := "mock_dag"
-	execTs := timeutils.ToString(time.Now())
+	execTs := timeutils.ToString(timeutils.Now())
 
 	for i := 0; i < N; i++ {
 		taskId := fmt.Sprintf("my_task_%d", i)
@@ -119,7 +119,7 @@ func TestReadDagRunTaskSingle(t *testing.T) {
 		t.Error(err)
 	}
 	dagId := "test_dag_1"
-	execTs := timeutils.ToString(time.Now())
+	execTs := timeutils.ToString(timeutils.Now())
 	taskId := "my_task_1"
 	ctx := context.Background()
 	insertDagRunTask(c, ctx, dagId, execTs, taskId, t)
@@ -162,7 +162,7 @@ func TestReadDagRunTaskLatestSingleDag(t *testing.T) {
 		taskId = "task1"
 	)
 	ctx := context.Background()
-	now := time.Now()
+	now := timeutils.Now()
 
 	type retryInfo struct {
 		retry  int
@@ -236,7 +236,7 @@ func TestReadDagRunTaskLatestManyDags(t *testing.T) {
 	}
 	defer CleanUpSqliteTmp(c, t)
 	ctx := context.Background()
-	now := time.Now()
+	now := timeutils.Now()
 
 	type retryInfo struct {
 		retry  int
@@ -321,7 +321,7 @@ func TestReadDagRunTaskUpdate(t *testing.T) {
 		t.Error(err)
 	}
 	dagId := "test_dag_1"
-	execTs := timeutils.ToString(time.Now())
+	execTs := timeutils.ToString(timeutils.Now())
 	taskId := "my_task_1"
 	ctx := context.Background()
 	insertDagRunTask(c, ctx, dagId, execTs, taskId, t)
@@ -394,7 +394,7 @@ func TestReadDagRunTasksNotFinishedSimple(t *testing.T) {
 	defer CleanUpSqliteTmp(c, t)
 	ctx := context.Background()
 	dId := "mock_dag_1"
-	ts := timeutils.ToString(time.Now())
+	ts := timeutils.ToString(timeutils.Now())
 
 	inputData := []struct {
 		taskId string
@@ -459,7 +459,7 @@ func TestRunningTasksNumAllFinished(t *testing.T) {
 
 	dags := []string{"mock_dag", "mock_dag_2"}
 	ctx := context.Background()
-	ts := timeutils.ToString(time.Now())
+	ts := timeutils.ToString(timeutils.Now())
 
 	data := []struct {
 		dagId  string
@@ -495,7 +495,7 @@ func TestRunningTasksNumWithRunningTasks(t *testing.T) {
 
 	dags := []string{"mock_dag", "mock_dag_2"}
 	ctx := context.Background()
-	ts := timeutils.ToString(time.Now())
+	ts := timeutils.ToString(timeutils.Now())
 
 	data := []struct {
 		dagId  string
@@ -531,7 +531,7 @@ func TestRunningTasksNumWithUpdate(t *testing.T) {
 
 	dagId := "mock_dag"
 	ctx := context.Background()
-	ts := timeutils.ToString(time.Now())
+	ts := timeutils.ToString(timeutils.Now())
 
 	data := []struct {
 		taskId string

--- a/db/logs_test.go
+++ b/db/logs_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/ppacer/core/timeutils"
 )
@@ -15,7 +14,7 @@ func TestInsertTaskLogSimple(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer CleanUpSqliteTmp(c, t)
-	ts := time.Now()
+	ts := timeutils.Now()
 	execTs := timeutils.ToString(ts)
 	const dagId = "mock_dag"
 	const taskId = "task_1"
@@ -68,7 +67,7 @@ func TestReadDagRunTaskLogsAllEmptyTable(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer CleanUpSqliteTmp(c, t)
-	ts := time.Now()
+	ts := timeutils.Now()
 	execTs := timeutils.ToString(ts)
 	const dagId = "mock_dag"
 	const taskId = "task_1"
@@ -92,7 +91,7 @@ func TestReadDagRunTaskLogsAll(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer CleanUpSqliteTmp(c, t)
-	ts := time.Now()
+	ts := timeutils.Now()
 	execTs := timeutils.ToString(ts)
 	const dagId = "mock_dag"
 	const taskId = "task_1"
@@ -113,7 +112,7 @@ func TestReadDagRunTaskLogsAll(t *testing.T) {
 			DagId:      dagId,
 			ExecTs:     execTs,
 			TaskId:     taskId,
-			InsertTs:   timeutils.ToString(time.Now()),
+			InsertTs:   timeutils.ToString(timeutils.Now()),
 			Level:      "INFO",
 			Message:    msg.Msg,
 			Attributes: msg.Attr,
@@ -153,7 +152,7 @@ func TestReadDagRunTaskLatest(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer CleanUpSqliteTmp(c, t)
-	ts := time.Now()
+	ts := timeutils.Now()
 	execTs := timeutils.ToString(ts)
 	const dagId = "mock_dag"
 	const taskId = "task_1"
@@ -175,7 +174,7 @@ func TestReadDagRunTaskLatest(t *testing.T) {
 			ExecTs:     execTs,
 			TaskId:     taskId,
 			Retry:      retry,
-			InsertTs:   timeutils.ToString(time.Now()),
+			InsertTs:   timeutils.ToString(timeutils.Now()),
 			Level:      "INFO",
 			Message:    msg.Msg,
 			Attributes: msg.Attr,
@@ -236,7 +235,7 @@ func BenchmarkInsertTaskLog(b *testing.B) {
 	}
 	const dagId = "mock_dag"
 	const taskId = "task"
-	ts := time.Now()
+	ts := timeutils.Now()
 	execTs := timeutils.ToString(ts)
 
 	tlr := TaskLogRecord{

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -33,6 +33,10 @@ type Config struct {
 
 	// Configuration for dagRunWatcher
 	DagRunWatcherConfig DagRunWatcherConfig
+
+	// Timezone name consistent with IANA Time Zone Database (e.g.
+	// "Europe/Warsaw" or "America/New_York").
+	TimezoneName string
 }
 
 // Default Scheduler configuration.
@@ -43,6 +47,7 @@ var DefaultConfig Config = Config{
 	StartupContextTimeout: 30 * time.Second,
 	TaskSchedulerConfig:   DefaultTaskSchedulerConfig,
 	DagRunWatcherConfig:   DefaultDagRunWatcherConfig,
+	TimezoneName:          "Local",
 }
 
 // Configuration for TaskScheduler which is responsible for scheduling tasks

--- a/scheduler/dagruns.go
+++ b/scheduler/dagruns.go
@@ -67,13 +67,13 @@ func (drw *DagRunWatcher) Watch(dags dag.Registry) {
 	ctx, cancel := context.WithTimeout(ctx, drw.config.DatabaseContextTimeout)
 	defer cancel()
 	nextSchedules := make(map[dag.Id]*time.Time)
-	drw.updateNextSchedules(ctx, dags, time.Now(), nextSchedules)
+	drw.updateNextSchedules(ctx, dags, timeutils.Now(), nextSchedules)
 	for {
 		if drw.schedulerStateFunc() == StateStopping {
 			drw.logger.Warn("Scheduler is stopping. DagRunWatcher will not schedule other runs.")
 			return
 		}
-		now := time.Now()
+		now := timeutils.Now()
 		drw.trySchedule(dags, nextSchedules, now)
 		time.Sleep(drw.config.WatchInterval)
 	}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -94,6 +94,17 @@ func (s *Scheduler) Start(dags dag.Registry) http.Handler {
 	cacheSize := s.config.DagRunTaskCacheLen
 	taskCache := ds.NewLruCache[DRTBase, DagRunTaskState](cacheSize)
 
+	// Setup timezone
+	if s.config.TimezoneName != timeutils.LocalTimezoneName {
+		tzSetErr := timeutils.SetTimezone(s.config.TimezoneName)
+		if tzSetErr != nil {
+			s.logger.Error(
+				"Couldn't setup custom timezone. Local timezone will be used",
+				"timezoneName", s.config.TimezoneName, "err", tzSetErr.Error(),
+			)
+		}
+	}
+
 	// Syncing queues with the database in case of program restarts.
 	s.setState(StateSynchronizing)
 	syncWithDatabase(dags, s.queues.DagRuns, s.dbClient, s.logger, s.config)

--- a/scheduler/tasks.go
+++ b/scheduler/tasks.go
@@ -235,7 +235,7 @@ func (ts *TaskScheduler) UpsertTaskStatus(ctx context.Context, drt DagRunTask, s
 
 //  Insert/update DAG run task info in the cache.
 func (ts *TaskScheduler) upsertTaskStatusCache(drt DagRunTask, status dag.TaskStatus) {
-	drts := DagRunTaskState{Status: status, StatusUpdateTs: time.Now()}
+	drts := DagRunTaskState{Status: status, StatusUpdateTs: timeutils.Now()}
 	drtsCache, entryExists := ts.taskCache.Get(drt.Base())
 	if !entryExists || (entryExists && drtsCache.Status != status) {
 		ts.taskCache.Put(drt.Base(), drts)

--- a/timeutils/utils.go
+++ b/timeutils/utils.go
@@ -6,18 +6,53 @@
 package timeutils
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 )
 
-const LOG_PREFIX = "timeutils"
+const (
+	// Timestamp format for time.Time serialization and deserialization. This
+	// format is used to store timestamps in the database.
+	TimestampFormat = "2006-01-02T15:04:05.999999MST-07:00"
 
-// Timestamp format for time.Time serialization and deserialization. This
-// format is used to store timestamps in the database.
-const TimestampFormat = "2006-01-02T15:04:05.999999MST-07:00"
+	// Date format for time.Time serialization and deserialization.
+	DateFormat = "2006-01-02"
 
-// Date format for time.Time serialization and deserialization.
-const DateFormat = "2006-01-02"
+	// String identifier for local time zone in standard time package.
+	LocalTimezoneName = "Local"
+)
+
+var (
+	// Timezone used Now and other functions which initialize time.Time.
+	ppacerTimezone *time.Location = time.Local
+
+	// In case we would need to mock time.Now() in our test suite.
+	timeNow func() time.Time = time.Now
+)
+
+// CurrentTz returns currently configured, on package level, timezone.
+func CurrentTz() *time.Location {
+	return ppacerTimezone
+}
+
+// SetTimezone sets package-level timezone. By default it's time.Local. If
+// incorrect timezone name is provided, then non-nil error is returned and the
+// timezone is not overwritten.
+func SetTimezone(timezoneName string) error {
+	location, parseErr := time.LoadLocation(timezoneName)
+	if parseErr != nil {
+		return fmt.Errorf("couldn't parse timezone based on name %s: %w",
+			timezoneName, parseErr)
+	}
+	ppacerTimezone = location
+	return nil
+}
+
+// Now return the current time in ppacer timezone.
+func Now() time.Time {
+	return timeNow().In(ppacerTimezone)
+}
 
 // ToString serialize give time.Time to string based on TimestampFormat format.
 func ToString(t time.Time) string {

--- a/timeutils/utils_test.go
+++ b/timeutils/utils_test.go
@@ -11,6 +11,48 @@ import (
 	"time"
 )
 
+func TestDefaultTimezone(t *testing.T) {
+	if ppacerTimezone != time.Local {
+		t.Errorf("Expected default timezone, to be Local, got: %v",
+			ppacerTimezone)
+	}
+}
+
+func TestSetTimezone(t *testing.T) {
+	for _, tzName := range timezoneNames() {
+		setErr := SetTimezone(tzName)
+		if setErr != nil {
+			t.Errorf("Failed setting up timezone to %s: %s",
+				tzName, setErr.Error())
+			continue
+		}
+		now := Now()
+		if now.Location().String() != tzName {
+			t.Errorf("Expected tiemstamp from %s timezone, got: %v", tzName,
+				now)
+		}
+	}
+	setErr := SetTimezone("Local")
+	if setErr != nil {
+		t.Errorf("Cannot set timezone back to Local: %s", setErr.Error())
+	}
+}
+
+func TestCurrentTz(t *testing.T) {
+	for _, tzName := range timezoneNames() {
+		setErr := SetTimezone(tzName)
+		if setErr != nil {
+			t.Errorf("Failed setting up timezone to %s: %s",
+				tzName, setErr.Error())
+			continue
+		}
+		now := time.Now().In(CurrentTz())
+		if now.Location().String() != tzName {
+			t.Errorf("Expected timestamp in %s timezone, got: %v", tzName, now)
+		}
+	}
+}
+
 func TestToStringBasic(t *testing.T) {
 	warsawTz := warsawTimeZone(t)
 	tss := []time.Time{
@@ -225,4 +267,23 @@ func randomTime(tz *time.Location) time.Time {
 	ns := rand.Intn(10000000) * 1000
 
 	return time.Date(year, time.Month(month), day, hour, minute, second, ns, tz)
+}
+
+func timezoneNames() []string {
+	return []string{
+		"Europe/Warsaw",
+		"Europe/Kiev",
+		"Europe/London",
+		"America/Bogota",
+		"America/Costa_Rica",
+		"America/Denver",
+		"America/Los_Angeles",
+		"America/New_York",
+		"Asia/Kamchatka",
+		"Asia/Kolkata",
+		"Asia/Pyongyang",
+		"Asia/Seoul",
+		"Asia/Vladivostok",
+		"Local",
+	}
 }


### PR DESCRIPTION
- Package `timeutils` contains information about set timezone. By default it's `Local` timezone.
- Scheduler on `Start` setups default timezone via `timeutils.SetTimezone` based on `scheduler.Config.TimezoneName`.
- Every related place which has been using `time.Now()` has been replaced with `timeutils.Now()` which takes into account timezone set in ppacer.