### PR TITLE
Add time outing task execution

### DIFF
--- a/db/logs.go
+++ b/db/logs.go
@@ -43,9 +43,9 @@ func (c *Client) InsertTaskLog(tlr TaskLogRecord) error {
 }
 
 // ReadDagRunLogs reads all task logs for given DAG run in chronological order.
-func (c *Client) ReadDagRunLogs(ctx context.Context, dagId, execTs string, retry int) ([]TaskLogRecord, error) {
+func (c *Client) ReadDagRunLogs(ctx context.Context, dagId, execTs string) ([]TaskLogRecord, error) {
 	rows, rErr := c.dbConn.QueryContext(ctx, c.readDagRunLogsQuery(), dagId,
-		execTs, retry)
+		execTs)
 	if rErr != nil {
 		c.logger.Error("Error while querying DAG run logs", "dagId", dagId,
 			"execTs", execTs, "err", rErr.Error())
@@ -172,7 +172,6 @@ func (c *Client) readDagRunLogsQuery() string {
 		WHERE
 				DagId = ?
 			AND ExecTs = ?
-			AND Retry = ?
 		ORDER BY
 			InsertTs ASC
 	`

--- a/e2etests/stress_test.go
+++ b/e2etests/stress_test.go
@@ -133,7 +133,7 @@ func testMaxGoroutineCount(
 	defer db.CleanUpSqliteTmp(dbClient, t)
 
 	sched, _, logsDbClient := schedulerWithSqlite(
-		queues, cfg, &notifications, dbClient, nil, t,
+		queues, cfg, &notifications, dbClient, nil, nil, t,
 	)
 
 	testServer := httptest.NewServer(sched.Start(ctx, dags))

--- a/e2etests/task_timeout_test.go
+++ b/e2etests/task_timeout_test.go
@@ -1,0 +1,41 @@
+package e2etests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ppacer/core/dag"
+	"github.com/ppacer/core/dag/schedule"
+	"github.com/ppacer/core/scheduler"
+)
+
+func TestSimpleDagRunWithTaskTimeout(t *testing.T) {
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	notifications := make([]string, 0)
+	dagId := dag.Id("mock_failing_dag")
+	d := simpleDAGWithLongRunningTasks(
+		dagId, schedule, 10*time.Hour, 100*time.Millisecond, &notifications,
+	)
+	dags.Add(d)
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+
+	testSchedulerE2eSingleDagRun(
+		dags, dr, 3*time.Second, false, &notifications, t,
+	)
+
+	if len(notifications) < 1 {
+		t.Fatalf("Expected at least 1 notification")
+	}
+	const expectedNotification = "CONTEXT IS DONE"
+	if notifications[0] != expectedNotification {
+		t.Errorf("Expected notification [%s], got: [%s]", expectedNotification,
+			notifications[0])
+	}
+}
+
+func TestSimpleDagRunWithManyTaskTimeouts(t *testing.T) {
+	// TODO!
+}

--- a/e2etests/task_timeout_test.go
+++ b/e2etests/task_timeout_test.go
@@ -1,20 +1,39 @@
 package e2etests
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ppacer/core/dag"
 	"github.com/ppacer/core/dag/schedule"
+	"github.com/ppacer/core/db"
 	"github.com/ppacer/core/scheduler"
+	"github.com/ppacer/core/timeutils"
 )
 
 func TestSimpleDagRunWithTaskTimeout(t *testing.T) {
+	logs := make([]string, 0, 100)
+	sw := newSliceWriter(&logs)
+	logger := sliceLogger(sw)
+
+	dbClient, err := db.NewSqliteTmpClient(testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	logsDbClient, err := db.NewSqliteTmpClientForLogs(testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.CleanUpSqliteTmp(dbClient, t)
+	defer db.CleanUpSqliteTmp(logsDbClient, t)
+
 	dags := dag.Registry{}
 	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
 	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
 	notifications := make([]string, 0)
-	dagId := dag.Id("mock_failing_dag")
+	dagId := dag.Id("timeouted_dag")
 	d := simpleDAGWithLongRunningTasks(
 		dagId, schedule, 10*time.Hour, 100*time.Millisecond, &notifications,
 	)
@@ -22,8 +41,9 @@ func TestSimpleDagRunWithTaskTimeout(t *testing.T) {
 	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
 	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
 
-	testSchedulerE2eSingleDagRun(
-		dags, dr, 3*time.Second, false, &notifications, t,
+	testSchedulerE2eSingleDagRunCustom(
+		dags, dr, 3*time.Second, false, &notifications, dbClient, logsDbClient,
+		nil, nil, logger, true, t,
 	)
 
 	if len(notifications) < 1 {
@@ -34,8 +54,113 @@ func TestSimpleDagRunWithTaskTimeout(t *testing.T) {
 		t.Errorf("Expected notification [%s], got: [%s]", expectedNotification,
 			notifications[0])
 	}
+
+	taskId := "task1"
+	dbLogs, logsReadErr := logsDbClient.ReadDagRunTaskLogs(
+		context.TODO(), string(dagId), timeutils.ToString(ts), taskId, 0,
+	)
+	if logsReadErr != nil {
+		t.Errorf("Cannot read task logs from the database: %s",
+			logsReadErr.Error())
+	}
+	if len(dbLogs) < 1 {
+		t.Fatalf("Expected at least 1 task log record, got: %d", len(dbLogs))
+	}
+
+	timeoutInTaskMsgs := false
+	for _, dbl := range dbLogs {
+		if strings.Contains(dbl.Message, "exceeded timeout") {
+			timeoutInTaskMsgs = true
+			break
+		}
+	}
+	if !timeoutInTaskMsgs {
+		t.Error("Expected timeout error in task logs, but couldn't find. Logs:")
+		for _, dbl := range dbLogs {
+			t.Logf("  -%s: %s\n", dbl.InsertTs, dbl.Message)
+		}
+	}
 }
 
 func TestSimpleDagRunWithManyTaskTimeouts(t *testing.T) {
-	// TODO!
+	const N = 10
+	logs := make([]string, 0, 100)
+	sw := newSliceWriter(&logs)
+	logger := sliceLogger(sw)
+
+	dbClient, err := db.NewSqliteTmpClient(testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	logsDbClient, err := db.NewSqliteTmpClientForLogs(testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.CleanUpSqliteTmp(dbClient, t)
+	defer db.CleanUpSqliteTmp(logsDbClient, t)
+
+	dags := dag.Registry{}
+	startTs := time.Date(2023, 11, 2, 12, 0, 0, 0, time.UTC)
+	var schedule schedule.Schedule = schedule.NewFixed(startTs, time.Hour)
+	notifications := make([]string, 0)
+	dagId := dag.Id("many_timeouts_dag")
+	d := manyParallelLongRunningsTasksDag(
+		N, dagId, schedule, 10*time.Hour, 100*time.Millisecond, &notifications,
+	)
+	dags.Add(d)
+	ts := time.Date(2024, 2, 4, 12, 0, 0, 0, time.UTC)
+	dr := scheduler.DagRun{DagId: dagId, AtTime: ts}
+
+	testSchedulerE2eSingleDagRunCustom(
+		dags, dr, 3*time.Second, false, &notifications, dbClient, logsDbClient,
+		nil, nil, logger, true, t,
+	)
+
+	if len(notifications) < N {
+		t.Fatalf("Expected at least %d notification", N)
+	}
+	const expectedNotification = "CONTEXT IS DONE"
+	contextIsDoneNotifications := 0
+
+	for _, notification := range notifications {
+		if notification == expectedNotification {
+			contextIsDoneNotifications++
+		}
+	}
+
+	if contextIsDoneNotifications < N {
+		t.Errorf("Expected %d notifications of the form [%s], got: %d",
+			N, expectedNotification, contextIsDoneNotifications)
+		t.Log("All notifications:")
+		for _, notification := range notifications {
+			t.Log(notification)
+		}
+	}
+
+	tlrs, logsReadErr := logsDbClient.ReadDagRunLogs(
+		context.TODO(), string(dagId), timeutils.ToString(ts),
+	)
+	if logsReadErr != nil {
+		t.Errorf("Cannot read task logs from the database: %s",
+			logsReadErr.Error())
+	}
+	if len(tlrs) < N {
+		t.Fatalf("Expected at least %d task log record, got: %d", N,
+			len(tlrs))
+	}
+
+	timeoutsInTaskLogs := 0
+	for _, dbl := range tlrs {
+		if strings.Contains(dbl.Message, "exceeded timeout") {
+			timeoutsInTaskLogs++
+		}
+	}
+	if timeoutsInTaskLogs < N {
+		t.Errorf("Expected timeout error in %d task logs, but got in %d",
+			N, timeoutsInTaskLogs)
+		t.Log("Task log records:")
+		for _, dbl := range tlrs {
+			t.Logf("  -%s: %s\n", dbl.InsertTs, dbl.Message)
+		}
+	}
 }

--- a/exec/executor.go
+++ b/exec/executor.go
@@ -61,7 +61,14 @@ func defaultConfig() Config {
 // nil, then default configuration values will be used. When logger is nil,
 // then slog for stdout with WARN severity level will be used. When notifier is
 // nil, then notify.NewLogsErr (notifications as logs) will be used.
-func New(schedAddr string, logDbClient *db.Client, polling pace.Strategy, logger *slog.Logger, config *Config, notifier notify.Sender) *Executor {
+func New(
+	schedAddr string,
+	logDbClient *db.Client,
+	polling pace.Strategy,
+	logger *slog.Logger,
+	config *Config,
+	notifier notify.Sender,
+) *Executor {
 	var cfg Config
 	if config != nil {
 		cfg = *config
@@ -137,30 +144,26 @@ func (e *Executor) Start(dags dag.Registry) {
 				tte.DagId, "taskId", tte.TaskId)
 			break
 		}
+		if taskNode == nil {
+			e.logger.Error("Node is nil", "tte", tte)
+			break
+		}
 		notifier := e.notifier
 		if taskNode.Config.Notifier != nil {
 			notifier = taskNode.Config.Notifier
 		}
 		e.waitIfCannotSpawnNewGoroutine()
 		atomic.AddInt64(e.goroutineCount, 1)
-		go executeTask(tte, taskNode.Task, e.schedClient, e.taskLogs, e.logger,
+		go executeTask(tte, taskNode, e.schedClient, e.taskLogs, e.logger,
 			notifier, e.goroutineCount)
 	}
 }
 
 func executeTask(
-	tte models.TaskToExec, task dag.Task, schedClient *scheduler.Client,
+	tte models.TaskToExec, node *dag.Node, schedClient *scheduler.Client,
 	taskLogs tasklog.Factory, logger *slog.Logger, notifier notify.Sender,
 	goroutineCount *int64,
 ) {
-	defer func() {
-		if r := recover(); r != nil {
-			stackAsErr := fmt.Errorf("%s", string(debug.Stack()))
-			schedClient.UpsertTaskStatus(tte, dag.TaskFailed, stackAsErr)
-			logger.Error("Recovered from panic:", "err", r, "stack",
-				string(debug.Stack()))
-		}
-	}()
 	defer atomic.AddInt64(goroutineCount, -1)
 	uErr := schedClient.UpsertTaskStatus(tte, dag.TaskRunning, nil)
 	if uErr != nil {
@@ -175,34 +178,72 @@ func executeTask(
 		return
 	}
 
-	// Executing
 	ri := dag.RunInfo{DagId: dag.Id(tte.DagId), ExecTs: execTs}
 	ti := tasklog.TaskInfo{
 		DagId:  tte.DagId,
 		ExecTs: execTs,
-		TaskId: task.Id(),
+		TaskId: node.Task.Id(),
 		Retry:  tte.Retry,
 	}
 
+	timeout := time.Duration(node.Config.TimeoutSeconds) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	taskContext := dag.TaskContext{
-		Context:  context.TODO(),
+		Context:  ctx,
 		Logger:   taskLogs.GetLogger(ti),
 		DagRun:   ri,
 		Notifier: notifier,
 	}
-	execErr := task.Execute(taskContext)
-	if execErr != nil {
-		logger.Error("Task finished with error", "tte", tte, "err",
-			execErr.Error())
-		schedClient.UpsertTaskStatus(tte, dag.TaskFailed, execErr)
-		return
-	}
 
-	logger.Info("Finished executing task", "taskToExec", tte)
-	uErr = schedClient.UpsertTaskStatus(tte, dag.TaskSuccess, nil)
-	if uErr != nil {
-		logger.Error("Error while updating status", "tte", tte, "status",
-			dag.TaskSuccess.String(), "err", uErr.Error())
+	// Executing
+	done := make(chan error, 1)
+	atomic.AddInt64(goroutineCount, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				stackAsErr := fmt.Errorf("%s", string(debug.Stack()))
+				schedClient.UpsertTaskStatus(tte, dag.TaskFailed, stackAsErr)
+				logger.Error("Recovered from panic:", "err", r, "stack",
+					string(debug.Stack()))
+			}
+		}()
+		defer atomic.AddInt64(goroutineCount, -1)
+		done <- node.Task.Execute(taskContext)
+	}()
+
+	select {
+	case <-ctx.Done():
+		logger.Error("Task execution exceeded timeout", "tte", tte, "timeout",
+			timeout)
+		tuErr := schedClient.UpsertTaskStatus(
+			tte, dag.TaskFailed,
+			fmt.Errorf("task execution exceeded timeout of %v", timeout),
+		)
+		if tuErr != nil {
+			logger.Error("Error while updating status", "tte", tte, "status",
+				dag.TaskFailed.String(), "err", tuErr.Error())
+		}
+
+	case execErr := <-done:
+		if execErr != nil {
+			logger.Error("Task finished with error", "tte", tte, "err",
+				execErr.Error())
+			tuErr := schedClient.UpsertTaskStatus(tte, dag.TaskFailed, execErr)
+			if tuErr != nil {
+				logger.Error("Error while updating status", "tte", tte,
+					"status", dag.TaskFailed.String(), "err", uErr.Error(),
+				)
+			}
+			return
+		}
+
+		logger.Info("Finished executing task", "taskToExec", tte)
+		uErr = schedClient.UpsertTaskStatus(tte, dag.TaskSuccess, nil)
+		if uErr != nil {
+			logger.Error("Error while updating status", "tte", tte, "status",
+				dag.TaskSuccess.String(), "err", uErr.Error())
+		}
 	}
 }
 

--- a/exec/executor.go
+++ b/exec/executor.go
@@ -201,7 +201,6 @@ func executeTask(
 	done := make(chan error, 1)
 	atomic.AddInt64(goroutineCount, 1)
 	go func() {
-		taskLogger := taskLogs.GetLogger(ti)
 		defer recoverTaskRuntimeErr(schedClient, logger, tte, taskLogger)
 		defer atomic.AddInt64(goroutineCount, -1)
 		done <- node.Task.Execute(taskContext)


### PR DESCRIPTION
- Task is executed in a separate goroutine.
- If `TaskConfig.TimeoutSeconds` would pass before task execution is done we are:
1. Cancelling task execution context.
2. Sending task log record with timeout error.
3. Logging timeout error.
4. Setting DAG run task status to `FAILED`.