### PR TITLE
/ui/dagrun/* endpoints in Scheduler HTTP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Not released changes
+
+- Introduce /ui/dagrun/* endpoints in Scheduler HTTP server, to hydrate the
+    main UI page.
+- Fix counting goroutines in TaskScheduler.
+
+
+
 # [v0.0.1] - 2024-07-24
 
 ## Backend - new features

--- a/api/core.go
+++ b/api/core.go
@@ -2,9 +2,10 @@
 // Licensed under the Apache License, Version 2.0.
 // See LICENSE file in the project root for full license information.
 
-// Package models contains types used for communication between executors and the scheduler.
-package models
+package api
 
+// TaskToExec contains information about a task which is scheduled to be
+// executed. Primarily to communicate between Scheduler and Executors.
 type TaskToExec struct {
 	DagId  string `json:"dagId"`
 	ExecTs string `json:"execTs"`
@@ -12,6 +13,8 @@ type TaskToExec struct {
 	Retry  int    `json:"retry"`
 }
 
+// DagRunTaskStatus contains information about DAG run task status and
+// potential execution error.
 type DagRunTaskStatus struct {
 	DagId   string  `json:"dagId"`
 	ExecTs  string  `json:"execTs"`

--- a/api/general.go
+++ b/api/general.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"time"
+
+	"github.com/ppacer/core/timeutils"
+)
+
+// Timestamp represents information about timestamp. ToDisplay is the field
+// which will be displayed on the UI as the main information. Other details,
+// like timezone might be used in tooltips.
+type Timestamp struct {
+	ToDisplay string `json:"toDisplay"`
+	Date      string `json:"date"`
+	Time      string `json:"time"`
+	Timezone  string `json:"timezone"`
+}
+
+// ToTimestamp converts given time into UI Timestamp information.
+func ToTimestamp(t time.Time) Timestamp {
+	timezoneName, _ := t.Zone()
+	return Timestamp{
+		ToDisplay: timeutils.ToStringUI(t),
+		Date:      t.Format(timeutils.UiDateFormat),
+		Time:      t.Format(timeutils.UiTimeDetailedFormat),
+		Timezone:  timezoneName,
+	}
+}

--- a/api/general_test.go
+++ b/api/general_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ppacer/core/timeutils"
+)
+
+func TestToTimstamp(t *testing.T) {
+	now := time.Now()
+	t1 := time.Date(
+		now.Year(), now.Month(), now.Day(), 13, 13, 13, 131000000,
+		time.UTC,
+	)
+	yestarday := t1.Add(-24 * time.Hour)
+	yDate := time.Date(
+		yestarday.Year(), yestarday.Month(), yestarday.Day(), 0, 0, 0, 0,
+		time.UTC,
+	)
+	yDateStr := yDate.Format(timeutils.UiDateFormat)
+
+	tests := []struct {
+		input    time.Time
+		expected Timestamp
+	}{
+		{
+			t1,
+			Timestamp{
+				ToDisplay: "13:13:13",
+				Date:      t1.Format(timeutils.UiDateFormat),
+				Time:      "13:13:13.131",
+				Timezone:  "UTC",
+			},
+		},
+		{
+			yestarday,
+			Timestamp{
+				ToDisplay: yDateStr + " " + "13:13:13",
+				Date:      yDateStr,
+				Time:      "13:13:13.131",
+				Timezone:  "UTC",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		res := ToTimestamp(test.input)
+		if res != test.expected {
+			t.Errorf("Expected %v, got: %v", test.expected, res)
+		}
+	}
+}
+
+func BenchmarkToTimestampToday(b *testing.B) {
+	now := time.Now()
+	for i := 0; i < b.N; i++ {
+		ToTimestamp(now)
+	}
+}
+
+func BenchmarkToTimestampOtherday(b *testing.B) {
+	yestarday := time.Now().Add(-24 * time.Hour)
+	for i := 0; i < b.N; i++ {
+		ToTimestamp(yestarday)
+	}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -47,7 +47,7 @@ func Routes() map[EndpointID]Endpoint {
 
 		// /ui/dagrun/*
 		EndpointUiDagrunStats:  {"GET /ui/dagrun/stats", "/ui/dagrun/stats"},
-		EndpointUiDagrunLatest: {"GET /ui/dagrun/latest", "/ui/dagrun/latest"},
+		EndpointUiDagrunLatest: {"GET /ui/dagrun/latest/{n}", "/ui/dagrun/latest"},
 		EndpointUiDagrunStatus: {"GET /ui/dagrun/status/{runId}", "/ui/dagrun/status/"},
 	}
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -18,6 +18,15 @@ const (
 
 	// Endpoint return current status of Scheduler.
 	EndpointState
+
+	// Endpoint returns statistics on DAG runs and scheduler queues.
+	EndpointUiDagrunStats
+
+	// Endpoint returns data on N latest DAG runs.
+	EndpointUiDagrunLatest
+
+	// Endpoint returns status for given DAG run ID.
+	EndpointUiDagrunStatus
 )
 
 // Endpoint contains information about an HTTP endpoint.
@@ -29,11 +38,16 @@ type Endpoint struct {
 // Routes for all Scheduler server endpoints.
 func Routes() map[EndpointID]Endpoint {
 	return map[EndpointID]Endpoint{
-		// /dag/task
+		// /dag/task/*
 		EndpointDagTaskPop:    {"GET /dag/task/pop", "/dag/task/pop"},
 		EndpointDagTaskUpdate: {"POST /dag/task/update", "/dag/task/update"},
 
 		// /state
 		EndpointState: {"GET /state", "/state"},
+
+		// /ui/dagrun/*
+		EndpointUiDagrunStats:  {"GET /ui/dagrun/stats", "/ui/dagrun/stats"},
+		EndpointUiDagrunLatest: {"GET /ui/dagrun/latest", "/ui/dagrun/latest"},
+		EndpointUiDagrunStatus: {"GET /ui/dagrun/status/{runId}", "/ui/dagrun/status/"},
 	}
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -1,0 +1,39 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+// Package api provieds information about Scheduler HTTP endpoints.
+package api
+
+// Identifier for Scheduler server endpoints.
+type EndpointID int
+
+const (
+	// Endpoint for taking the first task to be executed from Scheduler
+	// internal queue.
+	EndpointDagTaskPop EndpointID = iota
+
+	// Endpoint for updating status of given DAG run task.
+	EndpointDagTaskUpdate
+
+	// Endpoint return current status of Scheduler.
+	EndpointState
+)
+
+// Endpoint contains information about an HTTP endpoint.
+type Endpoint struct {
+	RoutePattern string
+	UrlSuffix    string
+}
+
+// Routes for all Scheduler server endpoints.
+func Routes() map[EndpointID]Endpoint {
+	return map[EndpointID]Endpoint{
+		// /dag/task
+		EndpointDagTaskPop:    {"GET /dag/task/pop", "/dag/task/pop"},
+		EndpointDagTaskUpdate: {"POST /dag/task/update", "/dag/task/update"},
+
+		// /state
+		EndpointState: {"GET /state", "/state"},
+	}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -24,9 +24,6 @@ const (
 
 	// Endpoint returns data on N latest DAG runs.
 	EndpointUiDagrunLatest
-
-	// Endpoint returns status for given DAG run ID.
-	EndpointUiDagrunStatus
 )
 
 // Endpoint contains information about an HTTP endpoint.
@@ -48,6 +45,5 @@ func Routes() map[EndpointID]Endpoint {
 		// /ui/dagrun/*
 		EndpointUiDagrunStats:  {"GET /ui/dagrun/stats", "/ui/dagrun/stats"},
 		EndpointUiDagrunLatest: {"GET /ui/dagrun/latest/{n}", "/ui/dagrun/latest"},
-		EndpointUiDagrunStatus: {"GET /ui/dagrun/status/{runId}", "/ui/dagrun/status/"},
 	}
 }

--- a/api/routes_test.go
+++ b/api/routes_test.go
@@ -9,6 +9,9 @@ func TestRoutesContainsAllEndpoints(t *testing.T) {
 		EndpointDagTaskPop,
 		EndpointDagTaskUpdate,
 		EndpointState,
+		EndpointUiDagrunStats,
+		EndpointUiDagrunLatest,
+		EndpointUiDagrunStatus,
 	}
 
 	routes := Routes()

--- a/api/routes_test.go
+++ b/api/routes_test.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestRoutesContainsAllEndpoints(t *testing.T) {
+	expectedEndpoints := []EndpointID{
+		EndpointDagTaskPop,
+		EndpointDagTaskUpdate,
+		EndpointState,
+	}
+
+	routes := Routes()
+
+	for _, endpointId := range expectedEndpoints {
+		if _, exist := routes[endpointId]; !exist {
+			t.Errorf("Expected endpointId %d does not exist in Routes",
+				endpointId)
+		}
+	}
+}

--- a/api/routes_test.go
+++ b/api/routes_test.go
@@ -11,7 +11,6 @@ func TestRoutesContainsAllEndpoints(t *testing.T) {
 		EndpointState,
 		EndpointUiDagrunStats,
 		EndpointUiDagrunLatest,
-		EndpointUiDagrunStatus,
 	}
 
 	routes := Routes()

--- a/api/ui_dagrun.go
+++ b/api/ui_dagrun.go
@@ -22,3 +22,19 @@ type UiDagrunStats struct {
 	TaskSchedulerQueueLen int          `json:"taskSchedulerQueueLen"`
 	GoroutinesNum         int64        `json:"goroutinesNum"`
 }
+
+// UiDagrunRow represents information on a single DAG run on the main UI page.
+type UiDagrunRow struct {
+	RunId            int64     `json:"runId"`
+	DagId            string    `json:"dagId"`
+	ExecTs           Timestamp `json:"execTs"`
+	InsertTs         Timestamp `json:"insertTs"`
+	Status           string    `json:"status"`
+	StatusUpdateTs   Timestamp `json:"statusUpdateTs"`
+	Duration         string    `json:"duration"`
+	TaskNum          int       `json:"taskNum"`
+	TaskCompletedNum int       `json:"taskCompletedNum"`
+}
+
+// UiDagrunList is a slice of UiDagrunRow.
+type UiDagrunList []UiDagrunRow

--- a/api/ui_dagrun.go
+++ b/api/ui_dagrun.go
@@ -1,0 +1,16 @@
+// Copyright 2023 The ppacer Authors.
+// Licensed under the Apache License, Version 2.0.
+// See LICENSE file in the project root for full license information.
+
+package api
+
+// UiDagrunStats is a struct for statistics on DAG runs and related metrics for
+// the main UI page.
+type UiDagrunStats struct {
+	DagrunsRunning        int `json:"dagrunsRunning"`
+	DagrunsFailed         int `json:"dagrunsFailed"`
+	DagrunQueueLen        int `json:"dagrunQueueLen"`
+	TaskSchedulerQueueLen int `json:"taskSchedulerQueueLen"`
+	TaskRunningNum        int `json:"taskRunningNum"`
+	GoroutinesNum         int `json:"goroutinesNum"`
+}

--- a/api/ui_dagrun.go
+++ b/api/ui_dagrun.go
@@ -20,7 +20,7 @@ type UIDagrunStats struct {
 	DagrunTasks           StatusCounts `json:"dagrunTasks"`
 	DagrunQueueLen        int          `json:"dagrunQueueLen"`
 	TaskSchedulerQueueLen int          `json:"taskSchedulerQueueLen"`
-	GoroutinesNum         int64        `json:"goroutinesNum"`
+	GoroutinesNum         int          `json:"goroutinesNum"`
 }
 
 // UIDagrunRow represents information on a single DAG run on the main UI page.

--- a/api/ui_dagrun.go
+++ b/api/ui_dagrun.go
@@ -13,9 +13,9 @@ type StatusCounts struct {
 	Running   int `json:"running"`
 }
 
-// UiDagrunStats is a struct for statistics on DAG runs and related metrics for
+// UIDagrunStats is a struct for statistics on DAG runs and related metrics for
 // the main UI page.
-type UiDagrunStats struct {
+type UIDagrunStats struct {
 	Dagruns               StatusCounts `json:"dagruns"`
 	DagrunTasks           StatusCounts `json:"dagrunTasks"`
 	DagrunQueueLen        int          `json:"dagrunQueueLen"`
@@ -23,8 +23,8 @@ type UiDagrunStats struct {
 	GoroutinesNum         int64        `json:"goroutinesNum"`
 }
 
-// UiDagrunRow represents information on a single DAG run on the main UI page.
-type UiDagrunRow struct {
+// UIDagrunRow represents information on a single DAG run on the main UI page.
+type UIDagrunRow struct {
 	RunId            int64     `json:"runId"`
 	DagId            string    `json:"dagId"`
 	ExecTs           Timestamp `json:"execTs"`
@@ -36,5 +36,5 @@ type UiDagrunRow struct {
 	TaskCompletedNum int       `json:"taskCompletedNum"`
 }
 
-// UiDagrunList is a slice of UiDagrunRow.
-type UiDagrunList []UiDagrunRow
+// UIDagrunList is a slice of UiDagrunRow.
+type UIDagrunList []UIDagrunRow

--- a/api/ui_dagrun.go
+++ b/api/ui_dagrun.go
@@ -4,13 +4,21 @@
 
 package api
 
+// StatusCounts keeps mapping between statuses (of dagruns, task execution,
+// etc) and their frequencies.
+type StatusCounts struct {
+	Success   int `json:"success"`
+	Failed    int `json:"failed"`
+	Scheduled int `json:"scheduled"`
+	Running   int `json:"running"`
+}
+
 // UiDagrunStats is a struct for statistics on DAG runs and related metrics for
 // the main UI page.
 type UiDagrunStats struct {
-	DagrunsRunning        int `json:"dagrunsRunning"`
-	DagrunsFailed         int `json:"dagrunsFailed"`
-	DagrunQueueLen        int `json:"dagrunQueueLen"`
-	TaskSchedulerQueueLen int `json:"taskSchedulerQueueLen"`
-	TaskRunningNum        int `json:"taskRunningNum"`
-	GoroutinesNum         int `json:"goroutinesNum"`
+	Dagruns               StatusCounts `json:"dagruns"`
+	DagrunTasks           StatusCounts `json:"dagrunTasks"`
+	DagrunQueueLen        int          `json:"dagrunQueueLen"`
+	TaskSchedulerQueueLen int          `json:"taskSchedulerQueueLen"`
+	GoroutinesNum         int64        `json:"goroutinesNum"`
 }

--- a/db/dagruns.go
+++ b/db/dagruns.go
@@ -501,7 +501,7 @@ func (c *Client) readDagRunWithTaskInfoQuery() string {
 			COUNT(DISTINCT drt.TaskId) AS TaskCompletedNum
 		FROM
 			dagruns dr
-		INNER JOIN
+		LEFT JOIN
 			dagtasks dt ON dr.DagId = dt.DagId AND dt.IsCurrent = 1
 		LEFT JOIN
 			dagruntasks drt ON

--- a/db/dagruns_test.go
+++ b/db/dagruns_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ppacer/core/dag"
 	"github.com/ppacer/core/timeutils"
 )
 
@@ -613,9 +614,117 @@ func TestReadDagRunsAggByStatus(t *testing.T) {
 	}
 }
 
+func TestReadDagRunsWithTaskInfo(t *testing.T) {
+	c, err := NewSqliteTmpClient(testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer CleanUpSqliteTmp(c, t)
+	ctx := context.Background()
+	const dagId = "mock_dag"
+	now := time.Now()
+	execTss := []string{
+		timeutils.ToString(now.Add(13 * 3 * time.Second)),
+		timeutils.ToString(now.Add(13 * 3 * 2 * time.Second)),
+		timeutils.ToString(now.Add(13 * 3 * 3 * time.Second)),
+	}
+	tasks := []string{"start", "t1", "t2", "finish"}
+
+	// prepare dagtasks, dagruns and dagruntasks tables
+	insertDagTasks(c, ctx, dagId, tasks, t)
+
+	for idx, execTs := range execTss {
+		insertDagRun(c, ctx, dagId, execTs, t)
+
+		if idx == 2 {
+			// we want to simulate no dag run tasks for DAG run [2].
+			continue
+		}
+		for _, task := range tasks {
+			insertDagRunTask(c, ctx, dagId, execTs, task, t)
+		}
+	}
+
+	// Update some DAG run tasks statuses:
+	//	DAG run [0] - all tasks are not yet done
+	//	DAG run [1] - 2 out of 4 tasks are done
+	//	DAG run [2] - no DAG run tasks yet at all
+	uErr1 := c.UpdateDagRunTaskStatus(
+		ctx, dagId, execTss[1], tasks[0], 0, statusSuccess,
+	)
+	if uErr1 != nil {
+		t.Errorf("Cannot update DAG run task status: %s", uErr1.Error())
+	}
+	uErr2 := c.UpdateDagRunTaskStatus(
+		ctx, dagId, execTss[1], tasks[1], 0, statusSuccess,
+	)
+	if uErr2 != nil {
+		t.Errorf("Cannot update DAG run task status: %s", uErr2.Error())
+	}
+
+	// query and assert
+	dagruns, rErr := c.ReadDagRunsWithTaskInfo(ctx, 5)
+	if rErr != nil {
+		t.Errorf("Error while reading DAG runs with Task info: %s",
+			rErr.Error())
+	}
+
+	if len(dagruns) != len(execTss) {
+		t.Errorf("Expected %d DAG runs with Task info, got: %d", len(execTss),
+			len(dagruns))
+	}
+
+	expected := []struct {
+		Idx              int
+		TaskNum          int
+		TaskCompletedNum int
+	}{
+		{2, 4, 0},
+		{1, 4, 2},
+		{0, 4, 0},
+	}
+
+	for id, e := range expected {
+		dr := dagruns[id]
+		if dr.DagRun.ExecTs != execTss[e.Idx] {
+			t.Errorf("For DAG run [%d] (row %d) expected execTs=%s, got: %s",
+				e.Idx, id, execTss[e.Idx], dr.DagRun.ExecTs)
+		}
+		if dr.TaskNum != e.TaskNum {
+			t.Errorf("Expected %d TaskNum for DAG run [%d], got: %d",
+				e.TaskNum, e.Idx, dr.TaskNum)
+		}
+		if dr.TaskCompletedNum != e.TaskCompletedNum {
+			t.Errorf("Expected %d completed task for DAG run [%d], got: %d",
+				e.TaskCompletedNum, e.Idx, dr.TaskCompletedNum)
+		}
+	}
+
+}
+
 func insertDagRun(c *Client, ctx context.Context, dagId, execTs string, t *testing.T) {
 	_, iErr := c.InsertDagRun(ctx, dagId, execTs)
 	if iErr != nil {
 		t.Errorf("Error while inserting dag run: %s", iErr.Error())
+	}
+}
+
+func insertDagTasks(c *Client, ctx context.Context, dagId string, tasks []string, t *testing.T) {
+	tx, txErr := c.dbConn.Begin()
+	if txErr != nil {
+		t.Fatalf("Cannot start SQL transaction: %s", txErr.Error())
+	}
+	for _, task := range tasks {
+		iErr := c.insertDagTask(
+			ctx, tx, dagId, dag.NewNode(PrintTask{Name: task}),
+			timeutils.ToString(time.Now()),
+		)
+		if iErr != nil {
+			t.Errorf("Cannot insert DAG task: %s", iErr.Error())
+		}
+	}
+	commErr := tx.Commit()
+	if commErr != nil {
+		t.Errorf("Cannot commit SQL transaction: %s", commErr.Error())
 	}
 }

--- a/db/dagruns_test.go
+++ b/db/dagruns_test.go
@@ -567,6 +567,7 @@ func TestReadDagRunsAggByStatus(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	defer CleanUpSqliteTmp(c, t)
 	ctx := context.Background()
 	dagId := "mock_dag"
 	timestamps := []string{

--- a/db/general.go
+++ b/db/general.go
@@ -75,3 +75,46 @@ func (c *Client) singleInt64(ctx context.Context, cntQuery string, args ...any) 
 		args, "duration", time.Since(start))
 	return count, nil
 }
+
+// Function groupBy2 executes usual SQL aggregation in form of:
+//
+// # SELECT Col1, F(Col2) FROM table GROUP BY Col1
+//
+// Query might be more complex, the only assumption is for it, to return two
+// columns of type K and V.
+func groupBy2[K comparable, V any](
+	ctx context.Context, dbConn DB, logger *slog.Logger, query string, args ...any,
+) (map[K]V, error) {
+	start := time.Now()
+	logger.Debug("Start groupBy2 query", "query", query, "args", args)
+	result := make(map[K]V)
+
+	rows, qErr := dbConn.QueryContext(ctx, query, args...)
+	if qErr != nil {
+		logger.Error("Cannot execute groupBy2 query", "query", query, "args",
+			args, "err", qErr.Error())
+	}
+	var key K
+	var value V
+
+	for rows.Next() {
+		select {
+		case <-ctx.Done():
+			// Handle context cancellation or deadline exceeded
+			logger.Warn("Context done while processing rows", "err", ctx.Err())
+			return nil, ctx.Err()
+		default:
+		}
+		scanErr := rows.Scan(&key, &value)
+		if scanErr != nil {
+			logger.Error("Error while scanning groupBy2 query results", "err",
+				scanErr.Error())
+			return nil, scanErr
+		}
+		result[key] = value
+	}
+
+	logger.Debug("Finished groupBy2 query", "query", query, "args", args,
+		"duration", time.Since(start))
+	return result, nil
+}

--- a/db/general_test.go
+++ b/db/general_test.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGroupBy2EmptyTable(t *testing.T) {
+	c, err := NewSqliteInMemoryClient(testLogger())
+	if err != nil {
+		t.Error(err)
+	}
+	ctx := context.Background()
+
+	query := "SELECT Status, COUNT(*) FROM dagruns GROUP BY Status"
+	res, qErr := groupBy2[string, int](ctx, c.dbConn, c.logger, query)
+	if qErr != nil {
+		t.Errorf("Error while groupBy2 on empty table: %s", qErr.Error())
+	}
+	if len(res) != 0 {
+		t.Errorf("Expected 0 results, got: %d", len(res))
+	}
+}
+
+func TestGroupBy2StringInt(t *testing.T) {
+	c, err := NewSqliteInMemoryClient(testLogger())
+	if err != nil {
+		t.Error(err)
+	}
+	ctx := context.Background()
+
+	dagId := "mock_dag"
+	timestamps := []string{
+		"2023-09-23T10:10:00",
+		"2023-09-23T10:20:00",
+		"2023-09-23T10:30:00",
+		"2023-09-23T10:40:00",
+		"2023-09-23T10:50:00",
+		"2023-09-23T11:00:00",
+	}
+	for _, ts := range timestamps {
+		insertDagRun(c, ctx, dagId, ts, t)
+	}
+
+	query := "SELECT Status, COUNT(*) FROM dagruns GROUP BY Status"
+	res, qErr := groupBy2[string, int](ctx, c.dbConn, c.logger, query)
+	if qErr != nil {
+		t.Errorf("Error while groupBy2: %s", qErr.Error())
+	}
+	if len(res) != 1 {
+		t.Errorf("Expected 1 result, got: %d", len(res))
+	}
+	dagruns, exists := res[DagRunTaskStatusScheduled]
+	if !exists {
+		t.Errorf("Expected key=%s to exist in aggregated results, but it does not",
+			DagRunTaskStatusScheduled)
+	}
+	if dagruns != len(timestamps) {
+		t.Errorf("Expectes %d DAG runs in status %s, but got: %d",
+			len(timestamps), DagRunTaskStatusScheduled, dagruns)
+	}
+}
+
+func TestGroupBy2StringString(t *testing.T) {
+	c, err := NewSqliteInMemoryClient(testLogger())
+	if err != nil {
+		t.Error(err)
+	}
+	ctx := context.Background()
+
+	dagId := "mock_dag"
+	timestamps := []string{
+		"2023-09-23T10:10:00",
+		"2023-09-23T10:20:00",
+		"2023-09-23T10:30:00",
+	}
+	for _, ts := range timestamps {
+		insertDagRun(c, ctx, dagId, ts, t)
+	}
+
+	query := "SELECT Status, MAX(DagId) FROM dagruns GROUP BY Status"
+	res, qErr := groupBy2[string, string](ctx, c.dbConn, c.logger, query)
+	if qErr != nil {
+		t.Errorf("Error while groupBy2: %s", qErr.Error())
+	}
+	if len(res) != 1 {
+		t.Errorf("Expected 1 result, got: %d", len(res))
+	}
+	resDagId, exists := res[DagRunTaskStatusScheduled]
+	if !exists {
+		t.Errorf("Expected key=%s to exist in aggregated results, but it does not",
+			DagRunTaskStatusScheduled)
+	}
+	if resDagId != dagId {
+		t.Errorf("Expected result dagId=%s for status %s, but got: %s",
+			dagId, DagRunTaskStatusScheduled, resDagId)
+	}
+}

--- a/exec/executor.go
+++ b/exec/executor.go
@@ -30,11 +30,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ppacer/core/api"
 	"github.com/ppacer/core/dag"
 	"github.com/ppacer/core/dag/tasklog"
 	"github.com/ppacer/core/db"
 	"github.com/ppacer/core/ds"
-	"github.com/ppacer/core/models"
 	"github.com/ppacer/core/notify"
 	"github.com/ppacer/core/pace"
 	"github.com/ppacer/core/scheduler"
@@ -177,7 +177,7 @@ func (e *Executor) Start(dags dag.Registry) {
 }
 
 func executeTask(
-	tte models.TaskToExec, node *dag.Node, schedClient *scheduler.Client,
+	tte api.TaskToExec, node *dag.Node, schedClient *scheduler.Client,
 	taskLogs tasklog.Factory, logger *slog.Logger, notifier notify.Sender,
 	goroutineCount *int64,
 ) {
@@ -260,7 +260,7 @@ func executeTask(
 }
 
 func recoverTaskRuntimeErr(
-	schedClient *scheduler.Client, logger *slog.Logger, tte models.TaskToExec,
+	schedClient *scheduler.Client, logger *slog.Logger, tte api.TaskToExec,
 	taskLogger *slog.Logger,
 ) {
 	if r := recover(); r != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,16 @@
 module github.com/ppacer/core
 
-go 1.21
+go 1.22
 
-require modernc.org/sqlite v1.25.0
+require (
+	github.com/lib/pq v1.10.9
+	modernc.org/sqlite v1.25.0
+)
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/mod v0.12.0 // indirect

--- a/scheduler/client.go
+++ b/scheduler/client.go
@@ -7,10 +7,12 @@ package scheduler
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"syscall"
 	"time"
 
 	"github.com/ppacer/core/api"
@@ -54,8 +56,10 @@ func (c *Client) GetTask() (api.TaskToExec, error) {
 		return api.TaskToExec{}, ds.ErrQueueIsEmpty
 	}
 	if err != nil {
-		c.logger.Error("Error while getting UI DAG runs stats", "err",
-			err.Error())
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			c.logger.Error("Error while getting TaskToExec", "err",
+				err.Error())
+		}
 		return api.TaskToExec{}, err
 	}
 	if code != http.StatusOK {

--- a/scheduler/client.go
+++ b/scheduler/client.go
@@ -7,7 +7,6 @@ package scheduler
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -29,7 +28,10 @@ type Client struct {
 
 // NewClient instantiate new Client. In case when HTTP client or logger are
 // nil, those would be initialized with default parameters.
-func NewClient(url string, httpClient *http.Client, logger *slog.Logger, config ClientConfig) *Client {
+func NewClient(
+	url string, httpClient *http.Client, logger *slog.Logger,
+	config ClientConfig,
+) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: config.HttpClientTimeout}
 	}
@@ -47,43 +49,29 @@ func NewClient(url string, httpClient *http.Client, logger *slog.Logger, config 
 // GetTask gets new task from scheduler to be executed by executor.
 func (c *Client) GetTask() (api.TaskToExec, error) {
 	startTs := time.Now()
-	var taskToExec api.TaskToExec
-
-	resp, err := c.httpClient.Get(c.getTaskUrl())
+	tte, code, err := httpGetJSON[api.TaskToExec](c.httpClient, c.getTaskUrl())
+	if code == http.StatusNoContent {
+		return api.TaskToExec{}, ds.ErrQueueIsEmpty
+	}
 	if err != nil {
-		return taskToExec, err
+		c.logger.Error("Error while getting UI DAG runs stats", "err",
+			err.Error())
+		return api.TaskToExec{}, err
 	}
-
-	body, rErr := io.ReadAll(resp.Body)
-	if rErr != nil {
-		return taskToExec, rErr
-	}
-
-	if resp.StatusCode == http.StatusNoContent {
-		return taskToExec, ds.ErrQueueIsEmpty
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		c.logger.Error("Got status code != 200 on GetTask response", "statuscode",
-			resp.StatusCode, "body", string(body))
-		return taskToExec, fmt.Errorf("got %d status code in GetTask response",
-			resp.StatusCode)
-	}
-
-	jErr := json.Unmarshal(body, &taskToExec)
-	if jErr != nil {
-		c.logger.Error("Unmarshal into APIResponse failed", "body", string(body),
-			"err", jErr)
-		return taskToExec, fmt.Errorf("couldn't unmarshal into telegram api.TaskToExec: %s",
-			jErr.Error())
+	if code != http.StatusOK {
+		err := fmt.Errorf("unexpected status code in UIDagrunStats request: %d",
+			code)
+		return api.TaskToExec{}, err
 	}
 	c.logger.Debug("GetTask finished", "duration", time.Since(startTs))
-	return taskToExec, nil
+	return *tte, nil
 }
 
 // UpsertTaskStatus either updates existing DAG run task status or inserts new
 // one.
-func (c *Client) UpsertTaskStatus(tte api.TaskToExec, status dag.TaskStatus, taskErr error) error {
+func (c *Client) UpsertTaskStatus(
+	tte api.TaskToExec, status dag.TaskStatus, taskErr error,
+) error {
 	start := time.Now()
 	statusStr := status.String()
 	c.logger.Debug("Start updating task status", "taskToExec", tte, "status",
@@ -153,9 +141,50 @@ func (c *Client) GetState() (State, error) {
 	return ParseState(stateJson.State)
 }
 
-func (c *Client) UiDagrunStats() (api.UiDagrunStats, error) {
-	// TODO
-	return api.UiDagrunStats{}, errors.New("NOT IMPLEMENTED")
+// UIDagrunStats returns the current statistics on DAG runs, its tasks and
+// goroutines.
+func (c *Client) UIDagrunStats() (api.UIDagrunStats, error) {
+	startTs := time.Now()
+	c.logger.Debug("Start UIDagrunStats request...")
+	stats, code, err := httpGetJSON[api.UIDagrunStats](
+		c.httpClient, c.uiDagrunStatsUrl(),
+	)
+	if err != nil {
+		c.logger.Error("Error while getting UI DAG runs stats", "err",
+			err.Error())
+		return api.UIDagrunStats{}, err
+	}
+	if code != http.StatusOK {
+		err := fmt.Errorf("unexpected status code in UIDagrunStats request: %d",
+			code)
+		return api.UIDagrunStats{}, err
+	}
+	c.logger.Debug("UIDagrunStats request finished", "duration",
+		time.Since(startTs))
+	return *stats, nil
+}
+
+// UIDagrunLatest returns information on latest n DAG runs and its tasks
+// completion.
+func (c *Client) UIDagrunLatest(n int) (api.UIDagrunList, error) {
+	startTs := time.Now()
+	c.logger.Debug("Start UIDagrunStats request...")
+	dagruns, code, err := httpGetJSON[api.UIDagrunList](
+		c.httpClient, c.uiDagrunLatestUrl(n),
+	)
+	if err != nil {
+		c.logger.Error("Error while getting latest DAG runs", "err",
+			err.Error())
+		return api.UIDagrunList{}, err
+	}
+	if code != http.StatusOK {
+		err := fmt.Errorf("unexpected status code in UIDagrunList request: %d",
+			code)
+		return api.UIDagrunList{}, err
+	}
+	c.logger.Debug("UIDagrunList request finished", "duration",
+		time.Since(startTs))
+	return *dagruns, nil
 }
 
 // Stop stops the Scheduler.
@@ -177,4 +206,44 @@ func (c *Client) getStateUrl() string {
 func (c *Client) getUpdateTaskStatusUrl() string {
 	suffix := c.routes[api.EndpointDagTaskUpdate].UrlSuffix
 	return fmt.Sprintf("%s%s", c.schedulerUrl, suffix)
+}
+
+func (c *Client) uiDagrunStatsUrl() string {
+	suffix := c.routes[api.EndpointUiDagrunStats]
+	return fmt.Sprintf("%s%s", c.schedulerUrl, suffix)
+}
+
+func (c *Client) uiDagrunLatestUrl(n int) string {
+	suffix := c.routes[api.EndpointUiDagrunLatest]
+	return fmt.Sprintf("%s%s/%d", c.schedulerUrl, suffix, n)
+}
+
+// Generic HTTP GET request with resp body deserialization from JSON into given
+// type.
+func httpGetJSON[T any](client *http.Client, url string) (*T, int, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, http.StatusBadRequest,
+			fmt.Errorf("failed to perform GET request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode,
+			fmt.Errorf("received non-200 response: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode,
+			fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var result T
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, resp.StatusCode,
+			fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return &result, resp.StatusCode, nil
 }

--- a/scheduler/client.go
+++ b/scheduler/client.go
@@ -209,12 +209,12 @@ func (c *Client) getUpdateTaskStatusUrl() string {
 }
 
 func (c *Client) uiDagrunStatsUrl() string {
-	suffix := c.routes[api.EndpointUiDagrunStats]
+	suffix := c.routes[api.EndpointUiDagrunStats].UrlSuffix
 	return fmt.Sprintf("%s%s", c.schedulerUrl, suffix)
 }
 
 func (c *Client) uiDagrunLatestUrl(n int) string {
-	suffix := c.routes[api.EndpointUiDagrunLatest]
+	suffix := c.routes[api.EndpointUiDagrunLatest].UrlSuffix
 	return fmt.Sprintf("%s%s/%d", c.schedulerUrl, suffix, n)
 }
 

--- a/scheduler/client_test.go
+++ b/scheduler/client_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ppacer/core/api"
 	"github.com/ppacer/core/dag"
 	"github.com/ppacer/core/db"
 	"github.com/ppacer/core/ds"
-	"github.com/ppacer/core/models"
 	"github.com/ppacer/core/notify"
 	"github.com/ppacer/core/timeutils"
 )
@@ -141,7 +141,7 @@ func TestClientUpsertTaskEmptyDb(t *testing.T) {
 	defer cancel()
 
 	schedClient := NewClient(testServer.URL, nil, nil, DefaultClientConfig)
-	tte := models.TaskToExec{
+	tte := api.TaskToExec{
 		DagId:  "mock_dag",
 		ExecTs: timeutils.ToString(time.Now()),
 		TaskId: "task1",
@@ -287,7 +287,7 @@ func TestClientGetStateSimple(t *testing.T) {
 }
 
 func taskToExecEqualsDRT(
-	task models.TaskToExec, expectedDrt DagRunTask, t *testing.T,
+	task api.TaskToExec, expectedDrt DagRunTask, t *testing.T,
 ) {
 	t.Helper()
 	if task.DagId != string(expectedDrt.DagId) {
@@ -303,8 +303,8 @@ func taskToExecEqualsDRT(
 	}
 }
 
-func newTaskToExec(dagId, execTs, taskId string) models.TaskToExec {
-	return models.TaskToExec{
+func newTaskToExec(dagId, execTs, taskId string) api.TaskToExec {
+	return api.TaskToExec{
 		DagId:  dagId,
 		ExecTs: execTs,
 		TaskId: taskId,

--- a/scheduler/client_test.go
+++ b/scheduler/client_test.go
@@ -328,10 +328,6 @@ func TestClientUIDagrunStatsEmpty(t *testing.T) {
 		t.Errorf("Expected empty api.UIDagrunStats.DagrunTasks, got: %v",
 			stats.DagrunTasks)
 	}
-	if stats.GoroutinesNum < 2 {
-		t.Errorf("Expected at least 2 goroutines on freshly started Scheduler, got: %d",
-			stats.GoroutinesNum)
-	}
 }
 
 func TestClientUIDagrunStats(t *testing.T) {

--- a/scheduler/client_test.go
+++ b/scheduler/client_test.go
@@ -31,7 +31,9 @@ func TestClientGetTaskEmptyDb(t *testing.T) {
 	defer testServer.Close()
 	defer cancel()
 
-	schedClient := NewClient(testServer.URL, nil, nil, DefaultClientConfig)
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
 	_, err := schedClient.GetTask()
 	if err == nil {
 		t.Error("Expected non-nil error for GetTask on empty database")
@@ -52,7 +54,9 @@ func TestClientGetTaskMockSingle(t *testing.T) {
 	defer testServer.Close()
 	defer cancel()
 
-	schedClient := NewClient(testServer.URL, nil, nil, DefaultClientConfig)
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
 
 	drt := DagRunTask{dag.Id("mock_dag"), time.Now(), "task1", 0}
 	putErr := queues.DagRunTasks.Put(drt)
@@ -95,7 +99,9 @@ func TestClientGetTaskMockMany(t *testing.T) {
 	defer db.CleanUpSqliteTmp(scheduler.dbClient, t)
 	defer testServer.Close()
 	defer cancel()
-	schedClient := NewClient(testServer.URL, nil, nil, DefaultClientConfig)
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
 
 	dagId := dag.Id("mock_dag")
 	data := []DagRunTask{
@@ -140,7 +146,9 @@ func TestClientUpsertTaskEmptyDb(t *testing.T) {
 	defer testServer.Close()
 	defer cancel()
 
-	schedClient := NewClient(testServer.URL, nil, nil, DefaultClientConfig)
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
 	tte := api.TaskToExec{
 		DagId:  "mock_dag",
 		ExecTs: timeutils.ToString(time.Now()),
@@ -166,7 +174,9 @@ func TestClientUpsertTaskSimpleUpdate(t *testing.T) {
 	defer db.CleanUpSqliteTmp(scheduler.dbClient, t)
 	defer testServer.Close()
 	defer cancel()
-	schedClient := NewClient(testServer.URL, nil, nil, DefaultClientConfig)
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
 
 	const dagId = "mock_dag"
 	execTs := timeutils.ToString(time.Now())
@@ -216,7 +226,9 @@ func TestClientUpsertSingleTaskFewStatuses(t *testing.T) {
 	defer db.CleanUpSqliteTmp(scheduler.dbClient, t)
 	defer testServer.Close()
 	defer cancel()
-	schedClient := NewClient(testServer.URL, nil, nil, DefaultClientConfig)
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
 
 	const dagId = "mock_dag"
 	execTs := time.Now()
@@ -265,12 +277,15 @@ func TestClientGetStateSimple(t *testing.T) {
 	defer testServer.Close()
 	defer cancel()
 
-	schedClient := NewClient(testServer.URL, nil, nil, DefaultClientConfig)
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
 	schedState, err := schedClient.GetState()
 	if err != nil {
 		t.Errorf("Error when getting scheduler state: %s", err.Error())
 	}
-	if schedState != StateStarted && schedState != StateSynchronizing && schedState != StateRunning {
+	if schedState != StateStarted && schedState != StateSynchronizing &&
+		schedState != StateRunning {
 		t.Errorf("Got unexpected Scheduler State: %s", schedState.String())
 	}
 
@@ -281,8 +296,213 @@ func TestClientGetStateSimple(t *testing.T) {
 			err2.Error())
 	}
 	if schedState2 != StateStopping {
-		t.Errorf("Expected Scheduled State %s, got: %s", StateStopping.String(),
-			schedState2.String())
+		t.Errorf("Expected Scheduled State %s, got: %s",
+			StateStopping.String(), schedState2.String())
+	}
+}
+
+func TestClientUIDagrunStatsEmpty(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	cfg := DefaultConfig
+	dags := dag.Registry{}
+	scheduler := schedulerWithSqlite(DefaultQueues(cfg), cfg, t)
+	testServer := httptest.NewServer(scheduler.Start(ctx, dags))
+	defer db.CleanUpSqliteTmp(scheduler.dbClient, t)
+	defer testServer.Close()
+	defer cancel()
+
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
+	stats, err := schedClient.UIDagrunStats()
+	if err != nil {
+		t.Errorf("Expected non-nil error for UIDagrunStats on empty database, got: %s",
+			err.Error())
+	}
+	var emptyStats api.StatusCounts
+	if stats.Dagruns != emptyStats {
+		t.Errorf("Expected empty api.UIDagrunStats.Dagruns, got: %v",
+			stats.Dagruns)
+	}
+	if stats.DagrunTasks != emptyStats {
+		t.Errorf("Expected empty api.UIDagrunStats.DagrunTasks, got: %v",
+			stats.DagrunTasks)
+	}
+	if stats.GoroutinesNum < 2 {
+		t.Errorf("Expected at least 2 goroutines on freshly started Scheduler, got: %d",
+			stats.GoroutinesNum)
+	}
+}
+
+func TestClientUIDagrunStats(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	cfg := DefaultConfig
+	dags := dag.Registry{}
+	scheduler := schedulerWithSqlite(DefaultQueues(cfg), cfg, t)
+	testServer := httptest.NewServer(scheduler.Start(ctx, dags))
+	defer db.CleanUpSqliteTmp(scheduler.dbClient, t)
+	defer testServer.Close()
+	defer cancel()
+
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
+
+	// prep data
+	const dagId = "sample_dag"
+	now := time.Now()
+
+	dagruns := []struct {
+		execTs string
+		status dag.RunStatus
+	}{
+		{timeutils.ToString(now), dag.RunScheduled},
+		{timeutils.ToString(now.Add(13 * time.Hour)), dag.RunRunning},
+	}
+
+	tasks := []struct {
+		execTs string
+		taskId string
+		status dag.TaskStatus
+	}{
+		{dagruns[1].execTs, "t1", dag.TaskSuccess},
+		{dagruns[1].execTs, "t2", dag.TaskSuccess},
+		{dagruns[1].execTs, "t3", dag.TaskRunning},
+	}
+
+	for _, dr := range dagruns {
+		insertDagRun(
+			scheduler.dbClient, ctx, dagId, dr.execTs, dr.status.String(), t,
+		)
+	}
+
+	for _, task := range tasks {
+		insertDagRunTask(
+			scheduler.dbClient, ctx, dagId, task.execTs, task.taskId,
+			task.status.String(), t,
+		)
+	}
+
+	// query stats
+	stats, err := schedClient.UIDagrunStats()
+	if err != nil {
+		t.Errorf("Unexpected error for UIDagrunStats: %s", err.Error())
+	}
+
+	expectedDagruns := api.StatusCounts{Scheduled: 1, Running: 1}
+	if stats.Dagruns != expectedDagruns {
+		t.Errorf("Expected stats for DAG runs %+v, but got: %+v",
+			expectedDagruns, stats.Dagruns)
+	}
+
+	expectedDagrunTasks := api.StatusCounts{Success: 2, Running: 1}
+	if stats.DagrunTasks != expectedDagrunTasks {
+		t.Errorf("Expected stats for DAG run tasks %+v, but got: %+v",
+			expectedDagrunTasks, stats.DagrunTasks)
+	}
+}
+
+func TestClientUIDagrunLatestEmpty(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	cfg := DefaultConfig
+	dags := dag.Registry{}
+	scheduler := schedulerWithSqlite(DefaultQueues(cfg), cfg, t)
+	testServer := httptest.NewServer(scheduler.Start(ctx, dags))
+	defer db.CleanUpSqliteTmp(scheduler.dbClient, t)
+	defer testServer.Close()
+	defer cancel()
+
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
+	dagruns1, err1 := schedClient.UIDagrunLatest(10)
+	if err1 != nil {
+		t.Errorf("Expected non-nil error for UIDagrunLatest on empty database, got: %s",
+			err1.Error())
+	}
+	dagruns2, err2 := schedClient.UIDagrunLatest(1)
+	if err2 != nil {
+		t.Errorf("Expected non-nil error for UIDagrunLatest on empty database, got: %s",
+			err2.Error())
+	}
+	if len(dagruns1) != 0 {
+		t.Errorf("Expected 0 dagruns on empty DB, got: %d", len(dagruns1))
+	}
+	if len(dagruns2) != 0 {
+		t.Errorf("Expected 0 dagruns on empty DB, got: %d", len(dagruns2))
+	}
+}
+
+func TestClientUIDagrunLatest(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	cfg := DefaultConfig
+	dags := dag.Registry{}
+	scheduler := schedulerWithSqlite(DefaultQueues(cfg), cfg, t)
+	testServer := httptest.NewServer(scheduler.Start(ctx, dags))
+	defer db.CleanUpSqliteTmp(scheduler.dbClient, t)
+	defer testServer.Close()
+	defer cancel()
+
+	schedClient := NewClient(
+		testServer.URL, nil, testLogger(), DefaultClientConfig,
+	)
+
+	// prep data
+	const dagId = "sample_dag"
+	now := time.Now()
+
+	dagruns := []struct {
+		execTs string
+		status dag.RunStatus
+	}{
+		{timeutils.ToString(now), dag.RunScheduled},
+		{timeutils.ToString(now.Add(13 * time.Hour)), dag.RunRunning},
+	}
+
+	tasks := []struct {
+		execTs string
+		taskId string
+		status dag.TaskStatus
+	}{
+		{dagruns[1].execTs, "t1", dag.TaskSuccess},
+		{dagruns[1].execTs, "t2", dag.TaskSuccess},
+		{dagruns[1].execTs, "t3", dag.TaskRunning},
+	}
+
+	for _, dr := range dagruns {
+		insertDagRun(
+			scheduler.dbClient, ctx, dagId, dr.execTs, dr.status.String(), t,
+		)
+	}
+
+	for _, task := range tasks {
+		insertDagRunTask(
+			scheduler.dbClient, ctx, dagId, task.execTs, task.taskId,
+			task.status.String(), t,
+		)
+	}
+
+	// query stats
+	drLatest, err := schedClient.UIDagrunLatest(10)
+	if err != nil {
+		t.Errorf("Unexpected error for UIDagrunLatest: %s", err.Error())
+	}
+
+	if len(drLatest) != len(dagruns) {
+		t.Errorf("Expected %d latest dag runs, got: %d", len(dagruns),
+			len(drLatest))
+	}
+	if drLatest[0].TaskNum != 0 {
+		t.Errorf("Expected TaskNum 0 (no dagatsks were inserted), got: %+v",
+			drLatest[0])
+	}
+	if drLatest[0].Status != dag.RunRunning.String() {
+		t.Errorf("Expected DAG run to be %s, but is %s",
+			dag.RunRunning.String(), drLatest[0].Status)
+	}
+	if drLatest[1].Status != dag.RunScheduled.String() {
+		t.Errorf("Expected DAG run to be %s, but is %s",
+			dag.RunScheduled.String(), drLatest[1].Status)
 	}
 }
 
@@ -322,6 +542,21 @@ func readDagRunTaskFromDb(
 			dagId, execTs, taskId, dbErr.Error())
 	}
 	return drt
+}
+
+func insertDagRun(
+	dbClient *db.Client, ctx context.Context, dagId, execTs, status string,
+	t *testing.T,
+) {
+	runId, iErr := dbClient.InsertDagRun(ctx, dagId, execTs)
+	if iErr != nil {
+		t.Fatalf("Cannot insert new DAG run: %s", iErr.Error())
+	}
+	uErr := dbClient.UpdateDagRunStatus(ctx, runId, status)
+	if uErr != nil {
+		t.Errorf("Cannot update DAG run (%d) status: %s", runId,
+			uErr.Error())
+	}
 }
 
 // Initialize Scheduler for tests.

--- a/scheduler/endpoints.go
+++ b/scheduler/endpoints.go
@@ -22,4 +22,5 @@ func (s *Scheduler) registerEndpoints(mux *http.ServeMux, ts *TaskScheduler) {
 
 	// /ui/dagrun/*
 	mux.HandleFunc(rp(api.EndpointUiDagrunStats), s.uiDagrunStatsHandler)
+	mux.HandleFunc(rp(api.EndpointUiDagrunLatest), s.uiDagrunListHandler)
 }

--- a/scheduler/endpoints.go
+++ b/scheduler/endpoints.go
@@ -9,11 +9,17 @@ import (
 // Register HTTP server endpoints for the Scheduler.
 func (s *Scheduler) registerEndpoints(mux *http.ServeMux, ts *TaskScheduler) {
 	r := api.Routes()
+	rp := func(e api.EndpointID) string {
+		return r[e].RoutePattern
+	}
 
-	// /dag/task
-	mux.HandleFunc(r[api.EndpointDagTaskPop].RoutePattern, ts.popTask)
-	mux.HandleFunc(r[api.EndpointDagTaskUpdate].RoutePattern, ts.upsertTaskStatus)
+	// /dag/task/*
+	mux.HandleFunc(rp(api.EndpointDagTaskPop), ts.popTask)
+	mux.HandleFunc(rp(api.EndpointDagTaskUpdate), ts.upsertTaskStatus)
 
 	// /state
-	mux.HandleFunc(r[api.EndpointState].RoutePattern, s.currentState)
+	mux.HandleFunc(rp(api.EndpointState), s.currentState)
+
+	// /ui/dagrun/*
+	mux.HandleFunc(rp(api.EndpointUiDagrunStats), s.uiDagrunStatsHandler)
 }

--- a/scheduler/endpoints.go
+++ b/scheduler/endpoints.go
@@ -23,4 +23,5 @@ func (s *Scheduler) registerEndpoints(mux *http.ServeMux, ts *TaskScheduler) {
 	// /ui/dagrun/*
 	mux.HandleFunc(rp(api.EndpointUiDagrunStats), s.uiDagrunStatsHandler)
 	mux.HandleFunc(rp(api.EndpointUiDagrunLatest), s.uiDagrunListHandler)
+
 }

--- a/scheduler/endpoints.go
+++ b/scheduler/endpoints.go
@@ -1,0 +1,19 @@
+package scheduler
+
+import (
+	"net/http"
+
+	"github.com/ppacer/core/api"
+)
+
+// Register HTTP server endpoints for the Scheduler.
+func (s *Scheduler) registerEndpoints(mux *http.ServeMux, ts *TaskScheduler) {
+	r := api.Routes()
+
+	// /dag/task
+	mux.HandleFunc(r[api.EndpointDagTaskPop].RoutePattern, ts.popTask)
+	mux.HandleFunc(r[api.EndpointDagTaskUpdate].RoutePattern, ts.upsertTaskStatus)
+
+	// /state
+	mux.HandleFunc(r[api.EndpointState].RoutePattern, s.currentState)
+}

--- a/scheduler/endpoints_dag_task.go
+++ b/scheduler/endpoints_dag_task.go
@@ -1,0 +1,94 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ppacer/core/dag"
+	"github.com/ppacer/core/ds"
+	"github.com/ppacer/core/models"
+	"github.com/ppacer/core/timeutils"
+)
+
+// HTTP handler for popping dag run task from the queue.
+func (ts *TaskScheduler) popTask(w http.ResponseWriter, _ *http.Request) {
+	if ts.taskQueue.Size() == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	drt, err := ts.taskQueue.Pop()
+	if err == ds.ErrQueueIsEmpty {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if err != nil {
+		errMsg := fmt.Sprintf("cannot get scheduled task from the queue: %s",
+			err.Error())
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	drtmodel := models.TaskToExec{
+		DagId:  string(drt.DagId),
+		ExecTs: timeutils.ToString(drt.AtTime),
+		TaskId: drt.TaskId,
+		Retry:  drt.Retry,
+	}
+	jsonBytes, jsonErr := json.Marshal(drtmodel)
+	if jsonErr != nil {
+		http.Error(w, jsonErr.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(jsonBytes)
+}
+
+// Updates task status in the task cache and the database.
+func (ts *TaskScheduler) upsertTaskStatus(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	if r.Method != "POST" {
+		http.Error(w, "Only POST requests are allowed",
+			http.StatusMethodNotAllowed)
+		return
+	}
+
+	var drts models.DagRunTaskStatus
+	err := json.NewDecoder(r.Body).Decode(&drts)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	execTs, tErr := timeutils.FromString(drts.ExecTs)
+	if tErr != nil {
+		msg := fmt.Sprintf("Given execTs timestamp in incorrect format: %s",
+			tErr.Error())
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+	status, statusErr := dag.ParseTaskStatus(drts.Status)
+	if statusErr != nil {
+		msg := fmt.Sprintf("Incorrect dag run task status: %s",
+			statusErr.Error())
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+	drt := DagRunTask{
+		DagId:  dag.Id(drts.DagId),
+		AtTime: execTs,
+		TaskId: drts.TaskId,
+		Retry:  drts.Retry,
+	}
+
+	ctx := context.TODO()
+	updateErr := ts.UpsertTaskStatus(ctx, drt, status, drts.TaskErr)
+	if updateErr != nil {
+		msg := fmt.Sprintf("Error while updating dag run task status: %s",
+			updateErr.Error())
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+	ts.logger.Debug("Updated task status", "dagruntask", drt, "status", status,
+		"duration", time.Since(start))
+}

--- a/scheduler/endpoints_dag_task.go
+++ b/scheduler/endpoints_dag_task.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ppacer/core/api"
 	"github.com/ppacer/core/dag"
 	"github.com/ppacer/core/ds"
-	"github.com/ppacer/core/models"
 	"github.com/ppacer/core/timeutils"
 )
 
@@ -31,7 +31,7 @@ func (ts *TaskScheduler) popTask(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	drtmodel := models.TaskToExec{
+	drtmodel := api.TaskToExec{
 		DagId:  string(drt.DagId),
 		ExecTs: timeutils.ToString(drt.AtTime),
 		TaskId: drt.TaskId,
@@ -54,7 +54,7 @@ func (ts *TaskScheduler) upsertTaskStatus(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	var drts models.DagRunTaskStatus
+	var drts api.DagRunTaskStatus
 	err := json.NewDecoder(r.Body).Decode(&drts)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/scheduler/endpoints_state.go
+++ b/scheduler/endpoints_state.go
@@ -1,0 +1,25 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// HTTP handler for getting the current Scheduler State.
+func (s *Scheduler) currentState(w http.ResponseWriter, _ *http.Request) {
+	s.Lock()
+	state := s.state
+	s.Unlock()
+
+	forJson := struct {
+		StateString string `json:"state"`
+	}{state.String()}
+
+	stateJson, jsonErr := json.Marshal(forJson)
+	if jsonErr != nil {
+		http.Error(w, jsonErr.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(stateJson))
+}

--- a/scheduler/endpoints_ui_dagrun.go
+++ b/scheduler/endpoints_ui_dagrun.go
@@ -3,20 +3,32 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/ppacer/core/api"
 	"github.com/ppacer/core/dag"
+	"github.com/ppacer/core/db"
+	"github.com/ppacer/core/timeutils"
 )
 
-// Timeout for HTTP request contexts.
-const HTTPRequestContextTimeout = 30 * time.Second
+const (
+	// Timeout for HTTP request contexts.
+	HTTPRequestContextTimeout = 30 * time.Second
+
+	defaultDagRunsListLen = 25
+)
 
 // HTTP handler for current statistics on DAG runs, Scheduler queues and
 // goroutines for the main ui page.
 func (s *Scheduler) uiDagrunStatsHandler(w http.ResponseWriter, _ *http.Request) {
-	ctx, cancel := context.WithTimeout(context.Background(), HTTPRequestContextTimeout)
+	start := time.Now()
+	s.logger.Debug("Start uiDagrunStatsHandler...")
+	ctx, cancel := context.WithTimeout(
+		context.Background(), HTTPRequestContextTimeout,
+	)
 	defer cancel()
 
 	dagrunStats, drErr := dagrunsDbStats(
@@ -25,6 +37,7 @@ func (s *Scheduler) uiDagrunStatsHandler(w http.ResponseWriter, _ *http.Request)
 	if drErr != nil {
 		errMsg := fmt.Sprintf("cannot get DAG runs stats from database: %s",
 			drErr.Error())
+		s.logger.Error(errMsg)
 		http.Error(w, errMsg, http.StatusInternalServerError)
 		return
 	}
@@ -34,6 +47,7 @@ func (s *Scheduler) uiDagrunStatsHandler(w http.ResponseWriter, _ *http.Request)
 	if tErr != nil {
 		errMsg := fmt.Sprintf("cannot get DAG runs stats from database: %s",
 			tErr.Error())
+		s.logger.Error(errMsg)
 		http.Error(w, errMsg, http.StatusInternalServerError)
 		return
 	}
@@ -53,6 +67,42 @@ func (s *Scheduler) uiDagrunStatsHandler(w http.ResponseWriter, _ *http.Request)
 		http.Error(w, encodeErr.Error(), http.StatusInternalServerError)
 		return
 	}
+	s.logger.Debug("Handler uiDagrunStatsHandler is finished", "duration",
+		time.Since(start))
+}
+
+func (s *Scheduler) uiDagrunListHandler(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	s.logger.Debug("Start uiDagrunLatest...")
+	ctx, cancel := context.WithTimeout(
+		context.Background(), HTTPRequestContextTimeout,
+	)
+	defer cancel()
+
+	n := parseDagRunsListLen(r, s.logger)
+
+	dagruns, dbErr := s.dbClient.ReadDagRunsWithTaskInfo(ctx, n)
+	if dbErr != nil {
+		errMsg := fmt.Sprintf("cannot read list of DAG runs from database: %s",
+			dbErr.Error())
+		s.logger.Error(errMsg)
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+	s.logger.Debug("Read dagruns with task info from database", "len",
+		len(dagruns))
+
+	dagrunList := prepDagrunList(dagruns)
+
+	encodeErr := encode(w, http.StatusOK, dagrunList)
+	if encodeErr != nil {
+		s.logger.Error("Cannot encode UiDagrunList", "len", len(dagruns),
+			"err", encodeErr.Error())
+		http.Error(w, encodeErr.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.logger.Debug("Handler uiDagrunListHandler is finished", "duration",
+		time.Since(start))
 }
 
 func dagrunsDbStats(
@@ -73,4 +123,42 @@ func dagrunsDbStats(
 		counts.Failed = cntFailed
 	}
 	return counts, nil
+}
+
+func parseDagRunsListLen(r *http.Request, logger *slog.Logger) int {
+	n := r.PathValue("n")
+	if n == "" {
+		logger.Warn("Got empty value for number of DAG runs")
+		return defaultDagRunsListLen
+	}
+	value, castErr := strconv.Atoi(n)
+	if castErr != nil {
+		logger.Warn("Cannot cast expected number of DAG runs <n> into int",
+			"n", n)
+		return defaultDagRunsListLen
+	}
+	return value
+}
+
+func prepDagrunList(dagruns []db.DagRunWithTaskInfo) api.UiDagrunList {
+	tsTransform := func(tsStr string) api.Timestamp {
+		return api.ToTimestamp(timeutils.FromStringMust(tsStr))
+	}
+	res := make(api.UiDagrunList, len(dagruns))
+	for idx, dr := range dagruns {
+		updateTs := timeutils.FromStringMust(dr.DagRun.StatusUpdateTs)
+		duration := updateTs.Sub(timeutils.FromStringMust(dr.DagRun.InsertTs))
+		res[idx] = api.UiDagrunRow{
+			RunId:            dr.DagRun.RunId,
+			DagId:            dr.DagRun.DagId,
+			ExecTs:           tsTransform(dr.DagRun.ExecTs),
+			InsertTs:         tsTransform(dr.DagRun.InsertTs),
+			Status:           dr.DagRun.Status,
+			StatusUpdateTs:   tsTransform(dr.DagRun.StatusUpdateTs),
+			Duration:         duration.String(),
+			TaskNum:          dr.TaskNum,
+			TaskCompletedNum: dr.TaskCompletedNum,
+		}
+	}
+	return res
 }

--- a/scheduler/endpoints_ui_dagrun.go
+++ b/scheduler/endpoints_ui_dagrun.go
@@ -1,0 +1,76 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ppacer/core/api"
+	"github.com/ppacer/core/dag"
+)
+
+// Timeout for HTTP request contexts.
+const HTTPRequestContextTimeout = 30 * time.Second
+
+// HTTP handler for current statistics on DAG runs, Scheduler queues and
+// goroutines for the main ui page.
+func (s *Scheduler) uiDagrunStatsHandler(w http.ResponseWriter, _ *http.Request) {
+	ctx, cancel := context.WithTimeout(context.Background(), HTTPRequestContextTimeout)
+	defer cancel()
+
+	dagrunStats, drErr := dagrunsDbStats(
+		ctx, s.dbClient.ReadDagRunsAggByStatus,
+	)
+	if drErr != nil {
+		errMsg := fmt.Sprintf("cannot get DAG runs stats from database: %s",
+			drErr.Error())
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+	tasksStats, tErr := dagrunsDbStats(
+		ctx, s.dbClient.ReadDagRunTasksAggByStatus,
+	)
+	if tErr != nil {
+		errMsg := fmt.Sprintf("cannot get DAG runs stats from database: %s",
+			tErr.Error())
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	stats := api.UiDagrunStats{
+		Dagruns:               dagrunStats,
+		DagrunTasks:           tasksStats,
+		DagrunQueueLen:        s.queues.DagRuns.Size(),
+		TaskSchedulerQueueLen: s.queues.DagRunTasks.Size(),
+		GoroutinesNum:         s.Goroutines(),
+	}
+
+	encodeErr := encode(w, http.StatusOK, stats)
+	if encodeErr != nil {
+		s.logger.Error("Cannot encode UiDagrunStats", "obj", stats, "err",
+			encodeErr.Error())
+		http.Error(w, encodeErr.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func dagrunsDbStats(
+	ctx context.Context, statsReader func(context.Context) (map[string]int, error),
+) (api.StatusCounts, error) {
+	var counts api.StatusCounts
+	cntByStatus, rErr := statsReader(ctx)
+	if rErr != nil {
+		return counts, rErr
+	}
+	if cntSuccess, successExists := cntByStatus[dag.RunSuccess.String()]; successExists {
+		counts.Success = cntSuccess
+	}
+	if cntRunning, runningExists := cntByStatus[dag.RunRunning.String()]; runningExists {
+		counts.Running = cntRunning
+	}
+	if cntFailed, failedExists := cntByStatus[dag.RunFailed.String()]; failedExists {
+		counts.Failed = cntFailed
+	}
+	return counts, nil
+}

--- a/scheduler/endpoints_ui_dagrun.go
+++ b/scheduler/endpoints_ui_dagrun.go
@@ -114,14 +114,21 @@ func dagrunsDbStats(
 	if rErr != nil {
 		return counts, rErr
 	}
-	if cntSuccess, successExists := cntByStatus[dag.RunSuccess.String()]; successExists {
+	cntSuccess, successExists := cntByStatus[dag.RunSuccess.String()]
+	if successExists {
 		counts.Success = cntSuccess
 	}
-	if cntRunning, runningExists := cntByStatus[dag.RunRunning.String()]; runningExists {
+	cntRunning, runningExists := cntByStatus[dag.RunRunning.String()]
+	if runningExists {
 		counts.Running = cntRunning
 	}
-	if cntFailed, failedExists := cntByStatus[dag.RunFailed.String()]; failedExists {
+	cntFailed, failedExists := cntByStatus[dag.RunFailed.String()]
+	if failedExists {
 		counts.Failed = cntFailed
+	}
+	cntScheduled, scheduledExists := cntByStatus[dag.RunScheduled.String()]
+	if scheduledExists {
+		counts.Scheduled = cntScheduled
 	}
 	return counts, nil
 }

--- a/scheduler/endpoints_ui_dagrun.go
+++ b/scheduler/endpoints_ui_dagrun.go
@@ -52,7 +52,7 @@ func (s *Scheduler) uiDagrunStatsHandler(w http.ResponseWriter, _ *http.Request)
 		return
 	}
 
-	stats := api.UiDagrunStats{
+	stats := api.UIDagrunStats{
 		Dagruns:               dagrunStats,
 		DagrunTasks:           tasksStats,
 		DagrunQueueLen:        s.queues.DagRuns.Size(),
@@ -141,15 +141,15 @@ func parseDagRunsListLen(r *http.Request, logger *slog.Logger) int {
 	return value
 }
 
-func prepDagrunList(dagruns []db.DagRunWithTaskInfo) api.UiDagrunList {
+func prepDagrunList(dagruns []db.DagRunWithTaskInfo) api.UIDagrunList {
 	tsTransform := func(tsStr string) api.Timestamp {
 		return api.ToTimestamp(timeutils.FromStringMust(tsStr))
 	}
-	res := make(api.UiDagrunList, len(dagruns))
+	res := make(api.UIDagrunList, len(dagruns))
 	for idx, dr := range dagruns {
 		updateTs := timeutils.FromStringMust(dr.DagRun.StatusUpdateTs)
 		duration := updateTs.Sub(timeutils.FromStringMust(dr.DagRun.InsertTs))
-		res[idx] = api.UiDagrunRow{
+		res[idx] = api.UIDagrunRow{
 			RunId:            dr.DagRun.RunId,
 			DagId:            dr.DagRun.DagId,
 			ExecTs:           tsTransform(dr.DagRun.ExecTs),

--- a/scheduler/endpoints_ui_dagrun.go
+++ b/scheduler/endpoints_ui_dagrun.go
@@ -71,6 +71,7 @@ func (s *Scheduler) uiDagrunStatsHandler(w http.ResponseWriter, _ *http.Request)
 		time.Since(start))
 }
 
+// HTTP handler for listing latest DAG runs and information about their tasks.
 func (s *Scheduler) uiDagrunListHandler(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	s.logger.Debug("Start uiDagrunLatest...")

--- a/scheduler/generic.go
+++ b/scheduler/generic.go
@@ -1,0 +1,26 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Functione encode JSON encodes and writes given object with given status.
+func encode[T any](w http.ResponseWriter, status int, v T) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		return fmt.Errorf("encode json: %w", err)
+	}
+	return nil
+}
+
+// Function decode decodes given HTTP request body into an expected type.
+func decode[T any](r *http.Request) (T, error) {
+	var v T
+	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+		return v, fmt.Errorf("decode json: %w", err)
+	}
+	return v, nil
+}

--- a/scheduler/generic_test.go
+++ b/scheduler/generic_test.go
@@ -1,0 +1,144 @@
+package scheduler
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type point struct {
+	X int     `json:"x"`
+	Y float64 `json:"y"`
+}
+
+func TestEncode(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputStatus  int
+		inputObject  interface{}
+		expectedJSON string
+		expectedCode int
+	}{
+		{
+			name:         "Test Encoding a Simple Object",
+			inputStatus:  http.StatusOK,
+			inputObject:  map[string]string{"key": "value"},
+			expectedJSON: `{"key":"value"}` + "\n",
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:        "Test Encoding a Complex Object",
+			inputStatus: http.StatusCreated,
+			inputObject: struct {
+				Name string `json:"name"`
+			}{Name: "GoLang"},
+			expectedJSON: `{"name":"GoLang"}` + "\n",
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:         "Test Encoding list of numbers",
+			inputStatus:  http.StatusCreated,
+			inputObject:  []int{42, 123, 52},
+			expectedJSON: `[42,123,52]` + "\n",
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:        "Test Encoding list of structs",
+			inputStatus: http.StatusCreated,
+			inputObject: []point{
+				{42, 3.14},
+				{-13, 43.43},
+			},
+			expectedJSON: `[{"x":42,"y":3.14},{"x":-13,"y":43.43}]` + "\n",
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:         "Test Encoding with Empty Object",
+			inputStatus:  http.StatusNoContent,
+			inputObject:  struct{}{},
+			expectedJSON: `{}` + "\n",
+			expectedCode: http.StatusNoContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			err := encode(rr, tt.inputStatus, tt.inputObject)
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+
+			contentType := rr.Header().Get("Content-Type")
+			if contentType != "application/json" {
+				t.Errorf("Expected Content-Type application/json, got %v",
+					contentType)
+			}
+			if status := rr.Code; status != tt.expectedCode {
+				t.Errorf("Expected status code %v, got %v", tt.expectedCode,
+					status)
+			}
+			if body := rr.Body.String(); body != tt.expectedJSON {
+				t.Errorf("Expected JSON %v, got %v", tt.expectedJSON, body)
+			}
+		})
+	}
+}
+
+func TestDecodeIntoMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputBody     string
+		expectedValue map[string]string
+		expectedError bool
+	}{
+		{
+			name:          "Decode Simple Object",
+			inputBody:     `{"key":"value","x":"y"}`,
+			expectedValue: map[string]string{"key": "value", "x": "y"},
+			expectedError: false,
+		},
+		{
+			name:          "Decode Invalid JSON",
+			inputBody:     `{"name": "GoLang",}`,
+			expectedValue: map[string]string{},
+			expectedError: true,
+		},
+		{
+			name:          "Decode Empty Body",
+			inputBody:     ``,
+			expectedValue: map[string]string{},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new request with the specified body
+			req := httptest.NewRequest("POST", "/", bytes.NewBufferString(tt.inputBody))
+
+			var result map[string]string
+			result, err := decode[map[string]string](req)
+			if (err != nil) != tt.expectedError {
+				t.Fatalf("Expected error: %v, got: %v", tt.expectedError, err)
+			}
+			if !tt.expectedError && !equalMaps(result, tt.expectedValue) {
+				t.Errorf("Expected: %v, got: %v", tt.expectedValue, result)
+			}
+		})
+	}
+}
+
+// Helper function to compare two maps
+func equalMaps(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -6,19 +6,16 @@ package scheduler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"log/slog"
 	"net/http"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/ppacer/core/dag"
 	"github.com/ppacer/core/db"
 	"github.com/ppacer/core/ds"
-	"github.com/ppacer/core/models"
 	"github.com/ppacer/core/notify"
 	"github.com/ppacer/core/timeutils"
 )
@@ -169,112 +166,6 @@ func (s *Scheduler) setState(newState State) {
 // Gets current number of goroutines spawned by Scheduler.
 func (s *Scheduler) Goroutines() int64 {
 	return atomic.LoadInt64(&s.goroutineCount)
-}
-
-// Register HTTP server endpoints for the Scheduler.
-func (s *Scheduler) registerEndpoints(mux *http.ServeMux, ts *TaskScheduler) {
-	mux.HandleFunc(getStateEndpoint, s.currentState)
-	mux.HandleFunc(getTaskEndpoint, ts.popTask)
-	mux.HandleFunc(upsertTaskStatusEndpoint, ts.upsertTaskStatus)
-}
-
-// HTTP handler for getting the current Scheduler State.
-func (s *Scheduler) currentState(w http.ResponseWriter, _ *http.Request) {
-	s.Lock()
-	state := s.state
-	s.Unlock()
-
-	forJson := struct {
-		StateString string `json:"state"`
-	}{state.String()}
-
-	stateJson, jsonErr := json.Marshal(forJson)
-	if jsonErr != nil {
-		http.Error(w, jsonErr.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(stateJson))
-}
-
-// HTTP handler for popping dag run task from the queue.
-func (ts *TaskScheduler) popTask(w http.ResponseWriter, _ *http.Request) {
-	if ts.taskQueue.Size() == 0 {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-	drt, err := ts.taskQueue.Pop()
-	if err == ds.ErrQueueIsEmpty {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-	if err != nil {
-		errMsg := fmt.Sprintf("cannot get scheduled task from the queue: %s",
-			err.Error())
-		http.Error(w, errMsg, http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	drtmodel := models.TaskToExec{
-		DagId:  string(drt.DagId),
-		ExecTs: timeutils.ToString(drt.AtTime),
-		TaskId: drt.TaskId,
-		Retry:  drt.Retry,
-	}
-	jsonBytes, jsonErr := json.Marshal(drtmodel)
-	if jsonErr != nil {
-		http.Error(w, jsonErr.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.Write(jsonBytes)
-}
-
-// Updates task status in the task cache and the database.
-func (ts *TaskScheduler) upsertTaskStatus(w http.ResponseWriter, r *http.Request) {
-	start := time.Now()
-	if r.Method != "POST" {
-		http.Error(w, "Only POST requests are allowed",
-			http.StatusMethodNotAllowed)
-		return
-	}
-
-	var drts models.DagRunTaskStatus
-	err := json.NewDecoder(r.Body).Decode(&drts)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	execTs, tErr := timeutils.FromString(drts.ExecTs)
-	if tErr != nil {
-		msg := fmt.Sprintf("Given execTs timestamp in incorrect format: %s",
-			tErr.Error())
-		http.Error(w, msg, http.StatusBadRequest)
-		return
-	}
-	status, statusErr := dag.ParseTaskStatus(drts.Status)
-	if statusErr != nil {
-		msg := fmt.Sprintf("Incorrect dag run task status: %s",
-			statusErr.Error())
-		http.Error(w, msg, http.StatusBadRequest)
-		return
-	}
-	drt := DagRunTask{
-		DagId:  dag.Id(drts.DagId),
-		AtTime: execTs,
-		TaskId: drts.TaskId,
-		Retry:  drts.Retry,
-	}
-
-	ctx := context.TODO()
-	updateErr := ts.UpsertTaskStatus(ctx, drt, status, drts.TaskErr)
-	if updateErr != nil {
-		msg := fmt.Sprintf("Error while updating dag run task status: %s",
-			updateErr.Error())
-		http.Error(w, msg, http.StatusInternalServerError)
-		return
-	}
-	ts.logger.Debug("Updated task status", "dagruntask", drt, "status", status,
-		"duration", time.Since(start))
 }
 
 // State for representing current Scheduler state.

--- a/scheduler/tasks.go
+++ b/scheduler/tasks.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/ppacer/core/dag"
@@ -78,8 +77,10 @@ type TaskScheduler struct {
 	config             TaskSchedulerConfig
 	logger             *slog.Logger
 	notifier           notify.Sender
-	goroutineCount     *int64
 	schedulerStateFunc GetStateFunc
+
+	gcMutex        sync.RWMutex
+	goroutineCount int
 
 	failedTaskManager   *failedTaskManager
 	taskRetriesExecuted *ds.AsyncMap[DRTBase, int]
@@ -94,7 +95,7 @@ func NewTaskScheduler(
 	config TaskSchedulerConfig,
 	logger *slog.Logger,
 	notifier notify.Sender,
-	goroutineCount *int64,
+	goroutineCountInit int,
 	schedulerStateFunc GetStateFunc,
 ) *TaskScheduler {
 	if logger == nil {
@@ -110,7 +111,7 @@ func NewTaskScheduler(
 		config:             config,
 		logger:             logger,
 		notifier:           notifier,
-		goroutineCount:     goroutineCount,
+		goroutineCount:     goroutineCountInit,
 		schedulerStateFunc: schedulerStateFunc,
 
 		failedTaskManager: newFailedTaskManager(
@@ -180,7 +181,12 @@ func (ts *TaskScheduler) Start(ctx context.Context, dags dag.Registry) {
 		ts.waitIfCannotSpawnNewGoroutine(
 			fmt.Sprintf("scheduling dagrun=%v", dagrun),
 		)
+		ts.logger.Debug("Starting new goroutine for scheduleDagTasks",
+			"dagrun", dagrun, "goroutineCount", ts.goroutines())
+		ts.gcMutex.Lock()
+		ts.goroutineCount++
 		go ts.scheduleDagTasks(ctx, d, dagrun, taskSchedulerErrors)
+		ts.gcMutex.Unlock()
 	}
 }
 
@@ -217,16 +223,20 @@ func (ts *TaskScheduler) UpsertTaskStatus(
 	}
 
 	if shouldBeRetried {
-		atomic.AddInt64(ts.goroutineCount, 1)
+		ts.logger.Debug("Starting new goroutine, to scheduleRetry", "drt", drt,
+			"goroutineCount", ts.goroutines())
+		ts.gcMutex.Lock()
+		ts.goroutineCount++
 		go func() {
 			// Let's remember that when we would restart Scheduler between
 			// particular DAG run task retries we might wait somewhere in
 			// [delay, 2 * delay) interval. For now it's fine, but let's make
 			// it resilient to Scheduler restarts.
-			defer atomic.AddInt64(ts.goroutineCount, -1)
+			defer ts.decreaseGoroutine()
 			time.Sleep(delay)
 			ts.scheduleRetry(drt)
 		}()
+		ts.gcMutex.Unlock()
 	}
 
 	if status != dag.TaskFailed {
@@ -312,8 +322,7 @@ func (ts *TaskScheduler) scheduleDagTasks(
 	dagrun DagRun,
 	errorsChan chan taskSchedulerError,
 ) {
-	atomic.AddInt64(ts.goroutineCount, 1)
-	defer atomic.AddInt64(ts.goroutineCount, -1)
+	defer ts.decreaseGoroutine()
 	dagId := string(dagrun.DagId)
 	ts.logger.Debug("Start scheduling tasks", "dagId", dagId, "execTs",
 		dagrun.AtTime)
@@ -447,9 +456,8 @@ func (ts *TaskScheduler) walkAndSchedule(
 	sharedState *dagRunSharedState,
 	wg *sync.WaitGroup,
 ) {
-	atomic.AddInt64(ts.goroutineCount, 1)
 	defer wg.Done()
-	defer atomic.AddInt64(ts.goroutineCount, -1)
+	defer ts.decreaseGoroutine()
 	checkDelay := ts.config.CheckDependenciesStatusWait
 	taskId := node.Task.Id()
 	ts.logger.Info("Start walkAndSchedule", "dagrun", dagrun, "taskId", taskId)
@@ -508,7 +516,12 @@ func (ts *TaskScheduler) walkAndSchedule(
 			ts.waitIfCannotSpawnNewGoroutine(
 				fmt.Sprintf("scheduling walkAndSchedule for drt=%v", drt),
 			)
+			ts.logger.Debug("Starting new goroutine for walkAndSchedule",
+				"drt", drt, "goroutineCount", ts.goroutines())
+			ts.gcMutex.Lock()
+			ts.goroutineCount++
 			go ts.walkAndSchedule(ctx, dagrun, child, sharedState, wg)
+			ts.gcMutex.Unlock()
 		}
 	}
 }
@@ -804,7 +817,7 @@ func (ts *TaskScheduler) cleanTaskCache(dagrun DagRun, nodes []dag.NodeInfo) {
 func (ts *TaskScheduler) waitIfCannotSpawnNewGoroutine(msg string) {
 	prevTs := time.Now()
 	for {
-		if atomic.LoadInt64(ts.goroutineCount) < int64(ts.config.MaxGoroutineCount) {
+		if ts.goroutines() < ts.config.MaxGoroutineCount {
 			return
 		}
 		now := time.Now()
@@ -814,6 +827,18 @@ func (ts *TaskScheduler) waitIfCannotSpawnNewGoroutine(msg string) {
 			prevTs = now
 		}
 	}
+}
+
+func (ts *TaskScheduler) goroutines() int {
+	ts.gcMutex.RLock()
+	defer ts.gcMutex.RUnlock()
+	return ts.goroutineCount
+}
+
+func (ts *TaskScheduler) decreaseGoroutine() {
+	ts.gcMutex.Lock()
+	defer ts.gcMutex.Unlock()
+	ts.goroutineCount--
 }
 
 func sendTaskSchedulerErr(

--- a/scheduler/tasks_test.go
+++ b/scheduler/tasks_test.go
@@ -1135,10 +1135,9 @@ func defaultTaskScheduler(t *testing.T, taskQueueCap int) *TaskScheduler {
 	notifications := make([]string, 0)
 	notifier := notify.NewMock(&notifications)
 
-	var goroutinesCount int64
 	ts := NewTaskScheduler(
 		registry, c, queues, taskCache, DefaultTaskSchedulerConfig,
-		testLogger(), notifier, &goroutinesCount, getStateFunc,
+		testLogger(), notifier, 0, getStateFunc,
 	)
 	return ts
 }

--- a/timeutils/utils.go
+++ b/timeutils/utils.go
@@ -21,6 +21,18 @@ const (
 
 	// String identifier for local time zone in standard time package.
 	LocalTimezoneName = "Local"
+
+	// Time format used on the UI.
+	UiTimeFormat = "15:04:05"
+
+	// As UiTimeFormat but including sub-second information.
+	UiTimeDetailedFormat = "15:04:05.999999"
+
+	// Date format used on the UI.
+	UiDateFormat = "2006-01-02"
+
+	// Timestamp format used on the UI for non-today timestamps.
+	UiTimestampFormat = "2006-01-02 15:04:05"
 )
 
 var (
@@ -54,9 +66,19 @@ func Now() time.Time {
 	return timeNow().In(ppacerTimezone)
 }
 
-// ToString serialize give time.Time to string based on TimestampFormat format.
+// ToString serialize given time.Time to string based on TimestampFormat format.
 func ToString(t time.Time) string {
 	return t.Format(TimestampFormat)
+}
+
+// ToStringUI serialize given time.Time to string based on Ui* formats. That
+// string is meant to be placed on the UI.
+func ToStringUI(t time.Time) string {
+	now := time.Now()
+	if t.Year() == now.Year() && t.YearDay() == now.YearDay() {
+		return t.Format(UiTimeFormat)
+	}
+	return t.Format(UiTimestampFormat)
 }
 
 // ToDateUTCString move given time.Time to UTC location and serialize it to

--- a/timeutils/utils_test.go
+++ b/timeutils/utils_test.go
@@ -248,6 +248,48 @@ func TestFromStringMustFailed(t *testing.T) {
 	}
 }
 
+func TestToStringUI(t *testing.T) {
+	t0 := time.Now()
+	t1 := time.Date(t0.Year(), t0.Month(), t0.Day(), 8, 59, 48, 987000000,
+		time.UTC)
+	dayBefore := t1.Add(-24 * time.Hour)
+	dateBefore := dayBefore.Format(UiDateFormat)
+
+	tests := []struct {
+		input    time.Time
+		expected string
+	}{
+		{t1, "08:59:48"},
+		{dayBefore, dateBefore + " 08:59:48"},
+	}
+
+	for _, test := range tests {
+		res := ToStringUI(test.input)
+		if res != test.expected {
+			t.Errorf("Expected ToStringUI(%v) = %s, got: %s", test.input,
+				test.expected, res)
+		}
+	}
+}
+
+func BenchmarkStringToStringUI(b *testing.B) {
+	x := time.Now()
+	xStr := ToString(x)
+
+	for i := 0; i < b.N; i++ {
+		ToStringUI(FromStringMust(xStr))
+	}
+}
+
+func BenchmarkFromStringMust(b *testing.B) {
+	x := time.Now()
+	xStr := ToString(x)
+
+	for i := 0; i < b.N; i++ {
+		FromStringMust(xStr)
+	}
+}
+
 func warsawTimeZone(t *testing.T) *time.Location {
 	location, err := time.LoadLocation("Europe/Warsaw")
 	if err != nil {


### PR DESCRIPTION
This PR adds new endpoints to hydrate the main page of the UI with DAG runs and its task information.
It also fixes counting goroutines in TaskScheduler.